### PR TITLE
Add static parameter generation for guides and services

### DIFF
--- a/app/api/search/featured/route.ts
+++ b/app/api/search/featured/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { SearchResultType, ServiceSearchResult } from '@/lib/search';
-import { getFeaturedServices, getAllServices } from '@/lib/content';
+import { getFeaturedServices } from '@/lib/content';
 
 export async function GET(request: NextRequest) {
   try {
@@ -24,42 +24,19 @@ export async function GET(request: NextRequest) {
     // Get all featured services from markdown files
     const featuredServicesData = await getFeaturedServices();
 
-    // If getFeaturedServices doesn't exist or fails, fall back to getting all services
-    // and filtering for featured ones
-    let featuredServices: ServiceSearchResult[] = [];
-
-    if (featuredServicesData.length > 0) {
-      // Transform the data to match the ServiceSearchResult interface
-      featuredServices = featuredServicesData.map(({ service }) => ({
-        id: service.name.toLowerCase().replace(/\s+/g, '-'),
-        title: service.name,
-        description: service.description,
-        url: `/services/non-eu/${service.name.toLowerCase().replace(/\s+/g, '-')}`,
-        type: 'service',
-        location: service.location,
-        category: service.category,
-        privacyRating: service.privacyRating,
-        freeOption: service.freeOption,
-        region: service.region || 'non-eu' // Default to non-eu if not specified
-      }));
-    } else {
-      // Fallback: get all services and filter for ones marked as featured
-      const allServices = await getAllServices();
-      featuredServices = allServices
-        .filter(service => service.featured === true)
-        .map(service => ({
-          id: service.name.toLowerCase().replace(/\s+/g, '-'),
-          title: service.name,
-          description: service.description,
-          url: `/services/non-eu/${service.name.toLowerCase().replace(/\s+/g, '-')}`,
-          type: 'service',
-          location: service.location,
-          category: service.category,
-          privacyRating: service.privacyRating,
-          freeOption: service.freeOption,
-          region: service.region || 'non-eu' // Default to non-eu if not specified
-        }));
-    }
+    // Transform the data to match the ServiceSearchResult interface
+    const featuredServices: ServiceSearchResult[] = featuredServicesData.map(({ service }) => ({
+      id: service.name.toLowerCase().replace(/\s+/g, '-'),
+      title: service.name,
+      description: service.description,
+      url: `/services/non-eu/${service.name.toLowerCase().replace(/\s+/g, '-')}`,
+      type: 'service',
+      location: service.location,
+      category: service.category,
+      privacyRating: service.privacyRating,
+      freeOption: service.freeOption,
+      region: service.region || 'non-eu' // Default to non-eu if not specified
+    }));
 
     console.log(`Featured API: Loaded ${featuredServices.length} featured services from content files`);
 

--- a/app/guides/[category]/[service]/page.tsx
+++ b/app/guides/[category]/[service]/page.tsx
@@ -1,10 +1,20 @@
-import { getGuide, extractMissingFeatures, extractMigrationSteps } from '@/lib/content';
+import { getGuide, extractMissingFeatures, extractMigrationSteps, getAllGuides } from '@/lib/content';
 import { notFound } from 'next/navigation';
 import { marked } from 'marked';
 import { Metadata } from 'next';
 import Script from 'next/script';
 import { GuideSidebar } from '@/components/guides/GuideSidebar';
 import { WarningCollapsible } from '@/components/guides/WarningCollapsible';
+
+// Generate static params for all guide pages
+export async function generateStaticParams() {
+  const guides = await getAllGuides();
+
+  return guides.map((guide) => ({
+    category: guide.category,
+    service: guide.slug,
+  }));
+}
 
 // Define params as a Promise type
 type Params = Promise<{

--- a/app/guides/[category]/page.tsx
+++ b/app/guides/[category]/page.tsx
@@ -1,7 +1,16 @@
 import Link from 'next/link';
-import { getGuidesByCategory } from '@/lib/content';
+import { getGuidesByCategory, getGuideCategories } from '@/lib/content';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
+
+// Generate static params for all guide category pages
+export async function generateStaticParams() {
+  const categories = await getGuideCategories();
+
+  return categories.map((category) => ({
+    category,
+  }));
+}
 
 // Define params as a Promise type
 type Params = Promise<{

--- a/app/services/[category]/page.tsx
+++ b/app/services/[category]/page.tsx
@@ -1,4 +1,4 @@
-import { getServicesByCategory, getCategoryContent } from '@/lib/content';
+import { getServicesByCategory, getCategoryContent, getAllServices, getAllCategoriesMetadata } from '@/lib/content';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { ServiceCard } from '@/components/ui/ServiceCard';
@@ -35,6 +35,15 @@ export async function generateMetadata(props: ServicesCategoryPageProps): Promis
     keywords: [capitalizedCategory, 'EU alternatives', 'privacy-focused services', 'GDPR compliant', category],
   };
 }
+
+export async function generateStaticParams() {
+  const categories = getAllCategoriesMetadata();
+
+  return categories.map((catgory) => ({
+    category: catgory.slug,
+  }))
+}
+
 
 export default async function ServicesCategoryPage(props: ServicesCategoryPageProps) {
   // Await the params Promise

--- a/app/services/[category]/page.tsx
+++ b/app/services/[category]/page.tsx
@@ -1,4 +1,4 @@
-import { getServicesByCategory, getCategoryContent, getAllServices, getAllCategoriesMetadata } from '@/lib/content';
+import { getServicesByCategory, getCategoryContent, getAllCategoriesMetadata } from '@/lib/content';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { ServiceCard } from '@/components/ui/ServiceCard';

--- a/app/services/eu/[service_name]/page.tsx
+++ b/app/services/eu/[service_name]/page.tsx
@@ -1,4 +1,4 @@
-import { getServiceBySlug, getGuidesByTargetService, getServicesByCategory } from '@/lib/content';
+import { getServiceBySlug, getGuidesByTargetService, getServicesByCategory, getServiceSlugs } from '@/lib/content';
 import { notFound } from 'next/navigation';
 import { RegionBadge } from '@/components/ui/region-badge';
 import Link from 'next/link';
@@ -17,6 +17,15 @@ type Params = Promise<{
 
 interface ServiceDetailPageProps {
   params: Params;
+}
+
+// Generate static params for all EU services
+export async function generateStaticParams() {
+  const serviceNames = await getServiceSlugs('eu');
+
+  return serviceNames.map((service_name) => ({
+    service_name,
+  }));
 }
 
 // Generate metadata for SEO

--- a/app/services/non-eu/[service_name]/page.tsx
+++ b/app/services/non-eu/[service_name]/page.tsx
@@ -1,4 +1,4 @@
-import { getServiceBySlug, getGuidesByTargetService, getServicesByCategory, getRecommendedAlternative } from '@/lib/content';
+import { getServiceBySlug, getGuidesByTargetService, getServicesByCategory, getRecommendedAlternative, getServiceSlugs } from '@/lib/content';
 import { notFound } from 'next/navigation';
 import { marked } from 'marked';
 import path from 'path';
@@ -15,6 +15,15 @@ type Params = Promise<{
 
 interface ServiceDetailPageProps {
   params: Params;
+}
+
+// Generate static params for all non-EU services
+export async function generateStaticParams() {
+  const serviceNames = await getServiceSlugs('non-eu');
+
+  return serviceNames.map((service_name) => ({
+    service_name,
+  }));
 }
 
 // Generate metadata for SEO

--- a/components/InlineSearchInput.tsx
+++ b/components/InlineSearchInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Search } from 'lucide-react';
 import { SearchResult, ServiceSearchResult } from '@/lib/search';
@@ -136,7 +136,7 @@ export function InlineSearchInput({
   }, [animatePlaceholder, query, placeholder]);
 
   // Fetch featured non-EU services for prefilled dropdown
-  const fetchFeaturedServices = async () => {
+  const fetchFeaturedServices = useCallback(async () => {
     try {
       // Adjust the API endpoint as needed
       let url = `/api/search/featured?region=non-eu`;
@@ -149,49 +149,14 @@ export function InlineSearchInput({
       setFeaturedServices(data.results || []);
     } catch (error) {
       console.error('Error fetching featured services:', error);
-
-      // Fallback to sample featured services if API fails
-      setFeaturedServices([
-        {
-          id: 'whatsapp',
-          title: 'WhatsApp',
-          description: 'Popular messaging app',
-          url: '/alternatives/whatsapp',
-          type: 'service',
-          region: 'non-eu'
-        } as ServiceSearchResult,
-        {
-          id: 'gmail',
-          title: 'Gmail',
-          description: 'Email service by Google',
-          url: '/alternatives/gmail',
-          type: 'service',
-          region: 'non-eu'
-        } as ServiceSearchResult,
-        {
-          id: 'instagram',
-          title: 'Instagram',
-          description: 'Social media platform',
-          url: '/alternatives/instagram',
-          type: 'service',
-          region: 'non-eu'
-        } as ServiceSearchResult,
-        {
-          id: 'google-drive',
-          title: 'Google Drive',
-          description: 'Cloud storage service',
-          url: '/alternatives/google-drive',
-          type: 'service',
-          region: 'non-eu'
-        } as ServiceSearchResult
-      ]);
+      setFeaturedServices([]);
     }
-  };
+  }, [showOnlyServices]);
 
   // Load featured services on component mount
   useEffect(() => {
     fetchFeaturedServices();
-  }, [showOnlyServices]);
+  }, [showOnlyServices, fetchFeaturedServices]);
 
   // Function to fetch search results from API
   const fetchResults = async (searchQuery: string) => {

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -883,3 +883,16 @@ export async function getRecommendedAlternative(serviceName: string): Promise<Se
 
     return alternativeService ? alternativeService.frontmatter : null;
 }
+
+/**
+ * Get all service slugs for a specific region
+ */
+export async function getServiceSlugs(region: 'eu' | 'non-eu'): Promise<string[]> {
+    const services = await getAllServices();
+    return services
+        .filter(service => service.region === region)
+        .map(service => {
+            // Convert service name to slug format (lowercase, spaces to hyphens)
+            return service.name.toLowerCase().replace(/\s+/g, '-');
+        });
+}

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -141,15 +141,7 @@ export async function buildSearchIndex(): Promise<Fuse<SearchResult>> {
         return searchIndex;
     } catch (error) {
         console.error('Error building search index:', error);
-
-        // Return an empty index if there was an error
-        const fallbackIndex = new Fuse<SearchResult>([], {
-            includeScore: true,
-            threshold: 0.4,
-            keys: ['title', 'description']
-        });
-
-        return fallbackIndex;
+        throw new Error(`Failed to build search index: ${error}`);
     }
 }
 


### PR DESCRIPTION
- Implemented `generateStaticParams` for guide category pages to fetch all categories.
- Added `generateStaticParams` for service pages to retrieve all service slugs for both EU and non-EU regions.
- Updated content library with a new function to get service slugs based on region.