### PR TITLE
fix: some links pointed to switch-to.eu/switch-to.eu instead of switc…

### DIFF
--- a/app/[locale]/guides/[category]/[service]/page.tsx
+++ b/app/[locale]/guides/[category]/[service]/page.tsx
@@ -286,7 +286,7 @@ export default async function GuideServicePage({
               </h2>
               <p className="mb-4">{serviceT("editGuide.description")}</p>
               <a
-                href="https://github.com/switch-to.eu/switch-to.eu"
+                href="https://github.com/switch-to-eu/switch-to.eu"
                 className="hover:underline"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -37,7 +37,7 @@ export async function Footer() {
         </div>
         <div className="flex items-center gap-4">
           <Link
-            href="https://github.com/switch-to.eu/switch-to.eu"
+            href="https://github.com/switch-to-eu/switch-to.eu"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm font-medium text-muted-foreground transition-colors hover:text-primary"


### PR DESCRIPTION
hi,

basically in the footer and category services pages, the link to this repo pointed to switch-to.eu/switch-to.eu instead of switch-to-eu/switch-to.eu