### PR TITLE
feat: add Plausible analytics, CSP headers, and fix privnote error handling

### DIFF
--- a/apps/privnote/components/create-note-form.tsx
+++ b/apps/privnote/components/create-note-form.tsx
@@ -30,6 +30,7 @@ export function CreateNoteForm() {
   const t = useTranslations("CreatePage");
   const v = useTranslations("validation");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const { control, handleSubmit, watch } = useForm<CreateNoteFormData>({
     resolver: zodResolver(createNoteSchema({
@@ -49,14 +50,16 @@ export function CreateNoteForm() {
   const contentLength = watch("content").length;
 
   const createNote = api.note.create.useMutation({
-    onError: () => {
+    onError: (err) => {
       setIsSubmitting(false);
+      setError(err.message || t("createError"));
     },
   });
 
   const onSubmit = async (data: CreateNoteFormData) => {
     if (isSubmitting) return;
     setIsSubmitting(true);
+    setError(null);
 
     const encryptionKey = await generateEncryptionKey();
     const encryptedContent = await encryptData(data.content.trim(), encryptionKey);
@@ -243,6 +246,13 @@ export function CreateNoteForm() {
           </Field>
         )}
       />
+
+      {/* Error message */}
+      {error && (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
 
       {/* Submit */}
       <Button

--- a/packages/i18n/messages/privnote/en.json
+++ b/packages/i18n/messages/privnote/en.json
@@ -101,7 +101,8 @@
     "passwordPlaceholder": "Enter a password",
     "termsLabel": "I agree to the <privacy>Privacy Policy</privacy> and <terms>Terms of Service</terms>",
     "createButton": "Create Note",
-    "creatingButton": "Creating..."
+    "creatingButton": "Creating...",
+    "createError": "Something went wrong. Please try again."
   },
   "SharePage": {
     "title": "Your note is ready!",

--- a/packages/i18n/messages/privnote/nl.json
+++ b/packages/i18n/messages/privnote/nl.json
@@ -101,7 +101,8 @@
     "passwordPlaceholder": "Voer een wachtwoord in",
     "termsLabel": "Ik ga akkoord met het <privacy>Privacybeleid</privacy> en de <terms>Servicevoorwaarden</terms>",
     "createButton": "Notitie Aanmaken",
-    "creatingButton": "Aanmaken..."
+    "creatingButton": "Aanmaken...",
+    "createError": "Er is iets misgegaan. Probeer het opnieuw."
   },
   "SharePage": {
     "title": "Uw notitie is klaar!",


### PR DESCRIPTION
## Summary
- **Plausible analytics** integrated across all 7 tool apps with per-subdomain tracking via `next-plausible`
- **CSP headers** standardized across all apps to allow Plausible script/connect sources
- **Fixed outdated domain URLs** in tools configuration (plotty, listy, privnote)
- **Fixed silent error handling** in privnote create form — mutation errors now display a visible error banner

## Test plan
- [ ] Verify Plausible script loads on each tool subdomain
- [ ] Verify CSP headers don't block Plausible or app functionality
- [ ] Test privnote creation — confirm error message appears if Redis is unavailable
- [ ] Verify all apps build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error notifications when note creation fails, displayed as alerts above the submit button.
  * Extended error message support to Dutch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->