### PR TITLE
fix: add media-src to CSP for guide videos

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -19,7 +19,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://plausible.io; media-src 'self' https://raw.githubusercontent.com" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://plausible.io; media-src 'self' https://github.com https://raw.githubusercontent.com" }
       ]
     }
   ],

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -19,7 +19,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://plausible.io" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://plausible.io; media-src 'self' https://raw.githubusercontent.com" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Adds `media-src 'self' https://raw.githubusercontent.com` to the website's Content Security Policy
- Fixes guide videos (e.g. Gmail to ProtonMail migration) being blocked because the CSP had no `media-src` directive, causing them to fall back to `default-src 'self'`

## Test plan
- [ ] Open a migration guide with embedded videos (e.g. `/en/guides/email/gmail-to-protonmail`)
- [ ] Verify videos load and play without CSP errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security configuration to support loading media from additional trusted sources. The site Content-Security-Policy was adjusted to add a dedicated media-src directive and include additional origins (e.g., GitHub-hosted raw content), improving safe media delivery without other header changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->