### PR TITLE
feat: set up Payload CMS foundation with route groups and admin panel

### DIFF
--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -9,7 +9,15 @@ const baseUrl = process.env.NEXT_PUBLIC_URL!;
 export const dynamic = "force-dynamic";
 
 // Define your static routes
-const staticRoutes = ["/", "/about", "/services", "/contact", "/tools/website"];
+const staticRoutes = [
+  "/",
+  "/about",
+  "/contribute",
+  "/tools",
+  "/privacy",
+  "/terms",
+  "/feedback",
+];
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   noStore();
@@ -66,10 +74,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }));
 
   const servicesEntries = servicesResult.docs.map((service: Service) => {
-    const serviceUrl =
-      service.region === "eu"
-        ? `/services/${service.slug}`
-        : `/services/${service.region}/${service.slug}`;
+    const regionPath =
+      service.region === "non-eu" ? "non-eu" : "eu";
+    const serviceUrl = `/services/${regionPath}/${service.slug}`;
 
     return {
       url: `${baseUrl}/${defaultLocale}${serviceUrl}`,


### PR DESCRIPTION
- Install Payload CMS dependencies (payload, @payloadcms/next,
  @payloadcms/db-postgres, @payloadcms/richtext-lexical,
  @payloadcms/translations, @payloadcms/storage-vercel-blob)
- Create payload.config.ts with Postgres adapter, Lexical editor,
  en/nl localization, and stub Categories/Media collections
- Create lib/payload.ts helper for getPayload() access
- Update next.config.ts: replace withMDX with withPayload, remove
  output: "standalone", remove content rewrite/CORS rules
- Add @payload-config path alias to tsconfig.json
- Split app into (frontend) and (payload) route groups
- Move all [locale] routes into (frontend)/[locale]
- Create Payload admin panel at /admin with RootPage/NotFoundPage
- Create Payload REST API catch-all at (payload)/api/[...slug]
- Update proxy.ts middleware to exclude /admin from i18n
- Add next override to prevent duplicate Next.js type resolution

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Payload CMS for centralized content management with draft/publish workflow
  * Added Claude AI skills for research, content writing, humanization, SEO audits, and multi-language translation
  * CMS admin interface for managing services, guides, categories, and pages with localization support

* **Chores**
  * Database migrations and configuration for new content infrastructure
  * Added seed utilities to migrate existing content into CMS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->