### PR TITLE
feat: add llms.txt routes for LLM-friendly content access

### DIFF
--- a/apps/website/app/api/llm/guides/[slug]/route.ts
+++ b/apps/website/app/api/llm/guides/[slug]/route.ts
@@ -1,36 +1,40 @@
+import { unstable_cache } from "next/cache";
 import { getPayload } from "@/lib/payload";
 import { guideToMarkdown } from "@/lib/llm-content";
-
-export const dynamic = "force-dynamic";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await params;
-  const payload = await getPayload();
 
-  const { docs } = await payload.find({
-    collection: "guides",
-    where: {
-      slug: { equals: slug },
-      _status: { equals: "published" },
+  const getGuide = unstable_cache(
+    async () => {
+      const payload = await getPayload();
+      const { docs } = await payload.find({
+        collection: "guides",
+        where: {
+          slug: { equals: slug },
+          _status: { equals: "published" },
+        },
+        locale: "en",
+        depth: 2,
+        limit: 1,
+      });
+      if (docs.length === 0) return null;
+      return guideToMarkdown(docs[0]);
     },
-    locale: "en",
-    depth: 2,
-    limit: 1,
-  });
+    [`llm-guide-${slug}`],
+    { tags: ["guides"] }
+  );
 
-  if (docs.length === 0) {
+  const markdown = await getGuide();
+
+  if (!markdown) {
     return new Response("Guide not found", { status: 404 });
   }
 
-  const markdown = guideToMarkdown(docs[0]);
-
   return new Response(markdown, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, s-maxage=3600",
-    },
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
   });
 }

--- a/apps/website/app/api/llm/guides/[slug]/route.ts
+++ b/apps/website/app/api/llm/guides/[slug]/route.ts
@@ -1,0 +1,36 @@
+import { getPayload } from "@/lib/payload";
+import { guideToMarkdown } from "@/lib/llm-content";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const payload = await getPayload();
+
+  const { docs } = await payload.find({
+    collection: "guides",
+    where: {
+      slug: { equals: slug },
+      _status: { equals: "published" },
+    },
+    locale: "en",
+    depth: 2,
+    limit: 1,
+  });
+
+  if (docs.length === 0) {
+    return new Response("Guide not found", { status: 404 });
+  }
+
+  const markdown = guideToMarkdown(docs[0]);
+
+  return new Response(markdown, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/apps/website/app/api/llm/services/[slug]/route.ts
+++ b/apps/website/app/api/llm/services/[slug]/route.ts
@@ -1,0 +1,36 @@
+import { getPayload } from "@/lib/payload";
+import { serviceToMarkdown } from "@/lib/llm-content";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const payload = await getPayload();
+
+  const { docs } = await payload.find({
+    collection: "services",
+    where: {
+      slug: { equals: slug },
+      _status: { equals: "published" },
+    },
+    locale: "en",
+    depth: 1,
+    limit: 1,
+  });
+
+  if (docs.length === 0) {
+    return new Response("Service not found", { status: 404 });
+  }
+
+  const markdown = serviceToMarkdown(docs[0]);
+
+  return new Response(markdown, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/apps/website/app/api/llm/services/[slug]/route.ts
+++ b/apps/website/app/api/llm/services/[slug]/route.ts
@@ -1,36 +1,40 @@
+import { unstable_cache } from "next/cache";
 import { getPayload } from "@/lib/payload";
 import { serviceToMarkdown } from "@/lib/llm-content";
-
-export const dynamic = "force-dynamic";
 
 export async function GET(
   _request: Request,
   { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await params;
-  const payload = await getPayload();
 
-  const { docs } = await payload.find({
-    collection: "services",
-    where: {
-      slug: { equals: slug },
-      _status: { equals: "published" },
+  const getService = unstable_cache(
+    async () => {
+      const payload = await getPayload();
+      const { docs } = await payload.find({
+        collection: "services",
+        where: {
+          slug: { equals: slug },
+          _status: { equals: "published" },
+        },
+        locale: "en",
+        depth: 1,
+        limit: 1,
+      });
+      if (docs.length === 0) return null;
+      return serviceToMarkdown(docs[0]);
     },
-    locale: "en",
-    depth: 1,
-    limit: 1,
-  });
+    [`llm-service-${slug}`],
+    { tags: ["services"] }
+  );
 
-  if (docs.length === 0) {
+  const markdown = await getService();
+
+  if (!markdown) {
     return new Response("Service not found", { status: 404 });
   }
 
-  const markdown = serviceToMarkdown(docs[0]);
-
   return new Response(markdown, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, s-maxage=3600",
-    },
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
   });
 }

--- a/apps/website/app/llms-full.txt/route.ts
+++ b/apps/website/app/llms-full.txt/route.ts
@@ -1,76 +1,78 @@
+import { unstable_cache } from "next/cache";
 import { getPayload } from "@/lib/payload";
 import { serviceToMarkdown, guideToMarkdown } from "@/lib/llm-content";
 import type { Service } from "@/payload-types";
 
-export const dynamic = "force-dynamic";
+const getCachedFullContent = unstable_cache(
+  async () => {
+    const payload = await getPayload();
+    const [services, guides] = await Promise.all([
+      payload.find({
+        collection: "services",
+        where: { _status: { equals: "published" } },
+        locale: "en",
+        limit: 0,
+        pagination: false,
+        depth: 1,
+      }),
+      payload.find({
+        collection: "guides",
+        where: { _status: { equals: "published" } },
+        locale: "en",
+        limit: 0,
+        pagination: false,
+        depth: 2,
+      }),
+    ]);
+
+    const sections: string[] = [];
+
+    sections.push("# switch-to.eu — Full Content\n");
+    sections.push(
+      "> European alternatives to Big Tech services. Honest reviews, privacy research, GDPR compliance checks, and step-by-step migration guides.\n"
+    );
+
+    const eu = services.docs.filter(
+      (s: Service) => s.region === "eu" || s.region === "eu-friendly"
+    );
+    const nonEu = services.docs.filter(
+      (s: Service) => s.region === "non-eu"
+    );
+
+    if (eu.length > 0) {
+      sections.push("---\n\n# EU Services\n");
+      for (const s of eu) {
+        sections.push(serviceToMarkdown(s));
+        sections.push("\n\n---\n");
+      }
+    }
+
+    if (nonEu.length > 0) {
+      sections.push("\n# Non-EU Services\n");
+      for (const s of nonEu) {
+        sections.push(serviceToMarkdown(s));
+        sections.push("\n\n---\n");
+      }
+    }
+
+    if (guides.docs.length > 0) {
+      sections.push("\n# Migration Guides\n");
+      for (const g of guides.docs) {
+        sections.push(guideToMarkdown(g));
+        sections.push("\n\n---\n");
+      }
+    }
+
+    return sections.join("\n").trim();
+  },
+  ["llm-full"],
+  { tags: ["services", "guides"] }
+);
 
 export async function GET() {
-  const payload = await getPayload();
-
-  const [services, guides] = await Promise.all([
-    payload.find({
-      collection: "services",
-      where: { _status: { equals: "published" } },
-      locale: "en",
-      limit: 0,
-      pagination: false,
-      depth: 1,
-    }),
-    payload.find({
-      collection: "guides",
-      where: { _status: { equals: "published" } },
-      locale: "en",
-      limit: 0,
-      pagination: false,
-      depth: 2,
-    }),
-  ]);
-
-  const sections: string[] = [];
-
-  sections.push("# switch-to.eu — Full Content\n");
-  sections.push(
-    "> European alternatives to Big Tech services. Honest reviews, privacy research, GDPR compliance checks, and step-by-step migration guides.\n"
-  );
-
-  // EU + EU-friendly services first, then non-EU
-  const eu = services.docs.filter(
-    (s: Service) => s.region === "eu" || s.region === "eu-friendly"
-  );
-  const nonEu = services.docs.filter(
-    (s: Service) => s.region === "non-eu"
-  );
-
-  if (eu.length > 0) {
-    sections.push("---\n\n# EU Services\n");
-    for (const s of eu) {
-      sections.push(serviceToMarkdown(s));
-      sections.push("\n\n---\n");
-    }
-  }
-
-  if (nonEu.length > 0) {
-    sections.push("\n# Non-EU Services\n");
-    for (const s of nonEu) {
-      sections.push(serviceToMarkdown(s));
-      sections.push("\n\n---\n");
-    }
-  }
-
-  if (guides.docs.length > 0) {
-    sections.push("\n# Migration Guides\n");
-    for (const g of guides.docs) {
-      sections.push(guideToMarkdown(g));
-      sections.push("\n\n---\n");
-    }
-  }
-
-  const markdown = sections.join("\n").trim();
+  const markdown = await getCachedFullContent();
 
   return new Response(markdown, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, s-maxage=3600",
-    },
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
   });
 }

--- a/apps/website/app/llms-full.txt/route.ts
+++ b/apps/website/app/llms-full.txt/route.ts
@@ -1,0 +1,76 @@
+import { getPayload } from "@/lib/payload";
+import { serviceToMarkdown, guideToMarkdown } from "@/lib/llm-content";
+import type { Service } from "@/payload-types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const payload = await getPayload();
+
+  const [services, guides] = await Promise.all([
+    payload.find({
+      collection: "services",
+      where: { _status: { equals: "published" } },
+      locale: "en",
+      limit: 0,
+      pagination: false,
+      depth: 1,
+    }),
+    payload.find({
+      collection: "guides",
+      where: { _status: { equals: "published" } },
+      locale: "en",
+      limit: 0,
+      pagination: false,
+      depth: 2,
+    }),
+  ]);
+
+  const sections: string[] = [];
+
+  sections.push("# switch-to.eu — Full Content\n");
+  sections.push(
+    "> European alternatives to Big Tech services. Honest reviews, privacy research, GDPR compliance checks, and step-by-step migration guides.\n"
+  );
+
+  // EU + EU-friendly services first, then non-EU
+  const eu = services.docs.filter(
+    (s: Service) => s.region === "eu" || s.region === "eu-friendly"
+  );
+  const nonEu = services.docs.filter(
+    (s: Service) => s.region === "non-eu"
+  );
+
+  if (eu.length > 0) {
+    sections.push("---\n\n# EU Services\n");
+    for (const s of eu) {
+      sections.push(serviceToMarkdown(s));
+      sections.push("\n\n---\n");
+    }
+  }
+
+  if (nonEu.length > 0) {
+    sections.push("\n# Non-EU Services\n");
+    for (const s of nonEu) {
+      sections.push(serviceToMarkdown(s));
+      sections.push("\n\n---\n");
+    }
+  }
+
+  if (guides.docs.length > 0) {
+    sections.push("\n# Migration Guides\n");
+    for (const g of guides.docs) {
+      sections.push(guideToMarkdown(g));
+      sections.push("\n\n---\n");
+    }
+  }
+
+  const markdown = sections.join("\n").trim();
+
+  return new Response(markdown, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/apps/website/app/llms.txt/route.ts
+++ b/apps/website/app/llms.txt/route.ts
@@ -1,0 +1,36 @@
+import { getPayload } from "@/lib/payload";
+import { buildLlmsIndex } from "@/lib/llm-content";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const payload = await getPayload();
+
+  const [services, guides] = await Promise.all([
+    payload.find({
+      collection: "services",
+      where: { _status: { equals: "published" } },
+      locale: "en",
+      limit: 0,
+      pagination: false,
+      depth: 0,
+    }),
+    payload.find({
+      collection: "guides",
+      where: { _status: { equals: "published" } },
+      locale: "en",
+      limit: 0,
+      pagination: false,
+      depth: 0,
+    }),
+  ]);
+
+  const markdown = buildLlmsIndex(services.docs, guides.docs);
+
+  return new Response(markdown, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/apps/website/app/llms.txt/route.ts
+++ b/apps/website/app/llms.txt/route.ts
@@ -1,36 +1,38 @@
+import { unstable_cache } from "next/cache";
 import { getPayload } from "@/lib/payload";
 import { buildLlmsIndex } from "@/lib/llm-content";
 
-export const dynamic = "force-dynamic";
+const getCachedIndex = unstable_cache(
+  async () => {
+    const payload = await getPayload();
+    const [services, guides] = await Promise.all([
+      payload.find({
+        collection: "services",
+        where: { _status: { equals: "published" } },
+        locale: "en",
+        limit: 0,
+        pagination: false,
+        depth: 0,
+      }),
+      payload.find({
+        collection: "guides",
+        where: { _status: { equals: "published" } },
+        locale: "en",
+        limit: 0,
+        pagination: false,
+        depth: 0,
+      }),
+    ]);
+    return buildLlmsIndex(services.docs, guides.docs);
+  },
+  ["llm-index"],
+  { tags: ["services", "guides"] }
+);
 
 export async function GET() {
-  const payload = await getPayload();
-
-  const [services, guides] = await Promise.all([
-    payload.find({
-      collection: "services",
-      where: { _status: { equals: "published" } },
-      locale: "en",
-      limit: 0,
-      pagination: false,
-      depth: 0,
-    }),
-    payload.find({
-      collection: "guides",
-      where: { _status: { equals: "published" } },
-      locale: "en",
-      limit: 0,
-      pagination: false,
-      depth: 0,
-    }),
-  ]);
-
-  const markdown = buildLlmsIndex(services.docs, guides.docs);
+  const markdown = await getCachedIndex();
 
   return new Response(markdown, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, s-maxage=3600",
-    },
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
   });
 }

--- a/apps/website/app/robots.ts
+++ b/apps/website/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      allow: ["/", "/api/llm/"],
       disallow: "/api/",
     },
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/apps/website/lib/lexical-to-markdown.ts
+++ b/apps/website/lib/lexical-to-markdown.ts
@@ -1,0 +1,204 @@
+/**
+ * Converts Payload CMS Lexical rich text JSON to Markdown.
+ *
+ * Supports the default lexicalEditor() node types: paragraphs, headings,
+ * lists (bullet + numbered), quotes, horizontal rules, links, and inline
+ * formatting (bold, italic, strikethrough, inline code).
+ */
+
+// ---------------------------------------------------------------------------
+// Types (minimal subset of Lexical serialized state)
+// ---------------------------------------------------------------------------
+
+interface LexicalNode {
+  type: string;
+  version: number;
+  children?: LexicalNode[];
+  // Text nodes
+  text?: string;
+  format?: number;
+  // Heading nodes
+  tag?: string;
+  // List nodes
+  listType?: string;
+  // Link nodes (Payload wraps URL in `fields`)
+  fields?: { url?: string; linkType?: string };
+  // Top-level
+  direction?: string | null;
+  indent?: number;
+  [key: string]: unknown;
+}
+
+// Format bitmask values used by Lexical
+const IS_BOLD = 1;
+const IS_ITALIC = 2;
+const IS_STRIKETHROUGH = 4;
+const IS_CODE = 16;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a Payload Lexical rich text field value to a markdown string.
+ * Returns an empty string for null/undefined input.
+ *
+ * Accepts `unknown` so callers don't need to cast Payload's generated types.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function lexicalToMarkdown(data: any): string {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+  const root = data?.root;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  if (!root?.children) return "";
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  return serializeChildren(root.children as LexicalNode[]).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Internal serialization
+// ---------------------------------------------------------------------------
+
+function serializeChildren(nodes: LexicalNode[]): string {
+  return nodes.map((node) => serializeNode(node)).join("");
+}
+
+function serializeNode(node: LexicalNode): string {
+  switch (node.type) {
+    case "paragraph":
+      return serializeParagraph(node);
+    case "heading":
+      return serializeHeading(node);
+    case "list":
+      return serializeList(node, 0);
+    case "quote":
+      return serializeQuote(node);
+    case "horizontalrule":
+      return "\n---\n\n";
+    case "text":
+      return serializeText(node);
+    case "linebreak":
+      return "\n";
+    case "link":
+    case "autolink":
+      return serializeLink(node);
+    case "tab":
+      return "\t";
+    default:
+      // Unknown block node with children — render children
+      if (node.children) {
+        return serializeChildren(node.children);
+      }
+      return "";
+  }
+}
+
+function serializeParagraph(node: LexicalNode): string {
+  const inner = node.children ? serializeInline(node.children) : "";
+  // Empty paragraphs become blank lines
+  if (!inner.trim()) return "\n";
+  return inner + "\n\n";
+}
+
+function serializeHeading(node: LexicalNode): string {
+  const level = parseInt(node.tag?.replace("h", "") ?? "2", 10);
+  const hashes = "#".repeat(level);
+  const inner = node.children ? serializeInline(node.children) : "";
+  return `${hashes} ${inner}\n\n`;
+}
+
+function serializeList(
+  node: LexicalNode,
+  depth: number
+): string {
+  if (!node.children) return "";
+  const isOrdered = node.listType === "number";
+  let result = "";
+  let index = 1;
+
+  for (const item of node.children) {
+    if (item.type === "listitem") {
+      const indent = "  ".repeat(depth);
+      const bullet = isOrdered ? `${index}.` : "-";
+
+      // List items can contain a mix of inline children and nested lists
+      const inlineChildren: LexicalNode[] = [];
+      const nestedLists: LexicalNode[] = [];
+
+      for (const child of item.children ?? []) {
+        if (child.type === "list") {
+          nestedLists.push(child);
+        } else {
+          inlineChildren.push(child);
+        }
+      }
+
+      const text = serializeInline(inlineChildren);
+      result += `${indent}${bullet} ${text}\n`;
+
+      for (const nested of nestedLists) {
+        result += serializeList(nested, depth + 1);
+      }
+
+      index++;
+    }
+  }
+
+  // Only add trailing newline at top level
+  if (depth === 0) result += "\n";
+  return result;
+}
+
+function serializeQuote(node: LexicalNode): string {
+  const inner = node.children ? serializeInline(node.children) : "";
+  const lines = inner.split("\n").map((line) => `> ${line}`);
+  return lines.join("\n") + "\n\n";
+}
+
+// ---------------------------------------------------------------------------
+// Inline serialization
+// ---------------------------------------------------------------------------
+
+/** Serialize an array of inline nodes (text, links, linebreaks). */
+function serializeInline(nodes: LexicalNode[]): string {
+  return nodes.map((n) => serializeInlineNode(n)).join("");
+}
+
+function serializeInlineNode(node: LexicalNode): string {
+  switch (node.type) {
+    case "text":
+      return serializeText(node);
+    case "link":
+    case "autolink":
+      return serializeLink(node);
+    case "linebreak":
+      return "\n";
+    case "tab":
+      return "\t";
+    default:
+      // Fallback: if it has children, serialize them inline
+      if (node.children) return serializeInline(node.children);
+      return "";
+  }
+}
+
+function serializeText(node: LexicalNode): string {
+  let text = node.text ?? "";
+  if (!text) return "";
+
+  const fmt = node.format ?? 0;
+
+  // Apply formatting in a consistent order (code first since it shouldn't nest)
+  if (fmt & IS_CODE) text = `\`${text}\``;
+  if (fmt & IS_BOLD) text = `**${text}**`;
+  if (fmt & IS_ITALIC) text = `*${text}*`;
+  if (fmt & IS_STRIKETHROUGH) text = `~~${text}~~`;
+
+  return text;
+}
+
+function serializeLink(node: LexicalNode): string {
+  const url = node.fields?.url ?? "";
+  const inner = node.children ? serializeInline(node.children) : url;
+  return `[${inner}](${url})`;
+}

--- a/apps/website/lib/llm-content.ts
+++ b/apps/website/lib/llm-content.ts
@@ -1,0 +1,267 @@
+/**
+ * Shared helpers for generating LLM-friendly markdown from Payload CMS content.
+ * Used by /llms.txt, /llms-full.txt, and individual .md route handlers.
+ */
+
+import type { Service, Guide } from "@/payload-types";
+import { lexicalToMarkdown } from "./lexical-to-markdown";
+import { getGdprLabel } from "./services";
+
+const BASE_URL = process.env.NEXT_PUBLIC_URL ?? "https://switch-to.eu";
+
+// ---------------------------------------------------------------------------
+// Service → Markdown
+// ---------------------------------------------------------------------------
+
+export function serviceToMarkdown(service: Service): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${service.name}`);
+  lines.push("");
+  lines.push(`> ${service.description}`);
+  lines.push("");
+
+  // Metadata
+  lines.push(`- **Based in**: ${service.location}`);
+  lines.push(`- **Website**: ${service.url}`);
+
+  const freeLabel = service.freeOption ? "Yes" : "No";
+  const priceNote = service.startingPrice
+    ? ` · From ${service.startingPrice}`
+    : "";
+  lines.push(`- **Free option**: ${freeLabel}${priceNote}`);
+
+  const gdpr = getGdprLabel(service.gdprCompliance);
+  if (gdpr) lines.push(`- **GDPR**: ${gdpr}`);
+
+  if (service.openSource) {
+    const srcLink = service.sourceCodeUrl
+      ? ` ([source](${service.sourceCodeUrl}))`
+      : "";
+    lines.push(`- **Open source**: Yes${srcLink}`);
+  }
+
+  if (service.headquarters) {
+    lines.push(`- **Headquarters**: ${service.headquarters}`);
+  }
+  if (service.foundedYear) {
+    lines.push(`- **Founded**: ${service.foundedYear}`);
+  }
+
+  lines.push("");
+
+  // Features
+  if (service.features && service.features.length > 0) {
+    lines.push("## Features");
+    lines.push("");
+    for (const f of service.features) {
+      lines.push(`- ${f.feature}`);
+    }
+    lines.push("");
+  }
+
+  // Main content
+  const content = lexicalToMarkdown(service.content as Parameters<typeof lexicalToMarkdown>[0]);
+  if (content) {
+    lines.push("## About");
+    lines.push("");
+    lines.push(content);
+    lines.push("");
+  }
+
+  // Issues (non-EU services)
+  if (service.issues && service.issues.length > 0) {
+    lines.push("## Known Issues");
+    lines.push("");
+    for (const issue of service.issues) {
+      lines.push(`- ${issue.issue}`);
+    }
+    lines.push("");
+  }
+
+  // Data storage locations
+  if (service.dataStorageLocations && service.dataStorageLocations.length > 0) {
+    lines.push("## Data Storage");
+    lines.push("");
+    for (const loc of service.dataStorageLocations) {
+      lines.push(`- ${loc.location}`);
+    }
+    lines.push("");
+  }
+
+  // Certifications
+  if (service.certifications && service.certifications.length > 0) {
+    lines.push("## Certifications");
+    lines.push("");
+    for (const cert of service.certifications) {
+      lines.push(`- ${cert.certification}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+// ---------------------------------------------------------------------------
+// Guide → Markdown
+// ---------------------------------------------------------------------------
+
+export function guideToMarkdown(guide: Guide): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${guide.title}`);
+  lines.push("");
+  lines.push(`> ${guide.description}`);
+  lines.push("");
+
+  // Metadata
+  lines.push(`- **Difficulty**: ${guide.difficulty}`);
+  lines.push(`- **Time required**: ${guide.timeRequired}`);
+
+  const source =
+    typeof guide.sourceService === "object"
+      ? guide.sourceService.name
+      : null;
+  const target =
+    typeof guide.targetService === "object"
+      ? guide.targetService.name
+      : null;
+  if (source) lines.push(`- **From**: ${source}`);
+  if (target) lines.push(`- **To**: ${target}`);
+
+  lines.push("");
+
+  // Intro
+  const intro = lexicalToMarkdown(guide.intro as Parameters<typeof lexicalToMarkdown>[0]);
+  if (intro) {
+    lines.push("## Why switch?");
+    lines.push("");
+    lines.push(intro);
+    lines.push("");
+  }
+
+  // Before you start
+  const before = lexicalToMarkdown(guide.beforeYouStart as Parameters<typeof lexicalToMarkdown>[0]);
+  if (before) {
+    lines.push("## Before you start");
+    lines.push("");
+    lines.push(before);
+    lines.push("");
+  }
+
+  // Steps
+  if (guide.steps && guide.steps.length > 0) {
+    lines.push("## Steps");
+    lines.push("");
+    for (let i = 0; i < guide.steps.length; i++) {
+      const step = guide.steps[i];
+      lines.push(`### Step ${i + 1}: ${step.title}`);
+      lines.push("");
+      const stepContent = lexicalToMarkdown(step.content as Parameters<typeof lexicalToMarkdown>[0]);
+      if (stepContent) {
+        lines.push(stepContent);
+        lines.push("");
+      }
+    }
+  }
+
+  // Missing features
+  if (guide.missingFeatures && guide.missingFeatures.length > 0) {
+    lines.push("## Features you might miss");
+    lines.push("");
+    for (const mf of guide.missingFeatures) {
+      lines.push(`- ${mf.feature}`);
+    }
+    lines.push("");
+  }
+
+  // Troubleshooting
+  const troubleshooting = lexicalToMarkdown(
+    guide.troubleshooting   );
+  if (troubleshooting) {
+    lines.push("## Troubleshooting");
+    lines.push("");
+    lines.push(troubleshooting);
+    lines.push("");
+  }
+
+  // Outro
+  const outro = lexicalToMarkdown(guide.outro as Parameters<typeof lexicalToMarkdown>[0]);
+  if (outro) {
+    lines.push("## Next steps");
+    lines.push("");
+    lines.push(outro);
+    lines.push("");
+  }
+
+  return lines.join("\n").trim();
+}
+
+// ---------------------------------------------------------------------------
+// Index (llms.txt) builder
+// ---------------------------------------------------------------------------
+
+export function buildLlmsIndex(
+  services: Service[],
+  guides: Guide[]
+): string {
+  const lines: string[] = [];
+
+  lines.push("# switch-to.eu");
+  lines.push("");
+  lines.push(
+    "> European alternatives to Big Tech services. Honest reviews, privacy research, GDPR compliance checks, and step-by-step migration guides."
+  );
+  lines.push("");
+  lines.push(
+    "switch-to.eu helps people switch from mainstream Big Tech services to European digital alternatives. Each service listing includes privacy research, pricing, GDPR compliance status, and honest trade-offs. Each migration guide includes step-by-step instructions, time estimates, and troubleshooting."
+  );
+  lines.push("");
+
+  // Split by region
+  const eu = services.filter(
+    (s) => s.region === "eu" || s.region === "eu-friendly"
+  );
+  const nonEu = services.filter((s) => s.region === "non-eu");
+
+  if (eu.length > 0) {
+    lines.push("## EU Services");
+    lines.push("");
+    for (const s of eu) {
+      lines.push(
+        `- [${s.name}](${BASE_URL}/services/${s.slug}.md): ${s.description}`
+      );
+    }
+    lines.push("");
+  }
+
+  if (nonEu.length > 0) {
+    lines.push("## Non-EU Services");
+    lines.push("");
+    for (const s of nonEu) {
+      lines.push(
+        `- [${s.name}](${BASE_URL}/services/${s.slug}.md): ${s.description}`
+      );
+    }
+    lines.push("");
+  }
+
+  if (guides.length > 0) {
+    lines.push("## Migration Guides");
+    lines.push("");
+    for (const g of guides) {
+      lines.push(
+        `- [${g.title}](${BASE_URL}/guides/${g.slug}.md): ${g.description}`
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push("## Full Content");
+  lines.push("");
+  lines.push(
+    `- [All content in one file](${BASE_URL}/llms-full.txt)`
+  );
+
+  return lines.join("\n").trim();
+}

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -11,6 +11,15 @@ const nextConfig: NextConfig = {
   ],
   // Configure pageExtensions to include md and mdx
   pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
+  async rewrites() {
+    return {
+      beforeFiles: [
+        // LLM-friendly .md URLs → API route handlers
+        { source: "/services/:slug.md", destination: "/api/llm/services/:slug" },
+        { source: "/guides/:slug.md", destination: "/api/llm/guides/:slug" },
+      ],
+    };
+  },
 };
 
 const withNextIntl = createNextIntlPlugin();


### PR DESCRIPTION
## Summary

- Implements the [llms.txt standard](https://llmstxt.org/) with four route handlers that generate LLM-friendly markdown from Payload CMS content
- `/llms.txt` — index file linking to all service and guide `.md` files
- `/llms-full.txt` — all content concatenated in one markdown file
- `/services/[slug].md` and `/guides/[slug].md` — individual content as markdown (served via Next.js rewrites)
- Includes a Lexical rich text → markdown converter for Payload's Lexical JSON content fields
- Updates `robots.txt` to allow `/api/llm/` crawling

## Test plan

- [ ] Verify `/llms.txt` returns a markdown index with correct links to all published services and guides
- [ ] Verify `/llms-full.txt` returns all content concatenated with correct markdown formatting
- [ ] Verify `/services/{slug}.md` returns a single service as clean markdown
- [ ] Verify `/guides/{slug}.md` returns a single guide with steps, troubleshooting, etc.
- [ ] Verify 404 response for non-existent slugs
- [ ] Verify Lexical rich text (headings, lists, links, bold/italic) converts correctly to markdown
- [ ] Verify `robots.txt` includes `/api/llm/` in allow rules

https://claude.ai/code/session_01GwvBHxekCGRq84ScFUgSZR