### PR TITLE
feat: set up Payload CMS foundation with route groups and admin panel

### DIFF
--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -147,7 +147,7 @@ export default async function GuideServicePage({
   const guideSteps = (guide.steps ?? []) as Array<{
     title: string;
     content: SerializedEditorState | null;
-    video?: string | null;
+    video?: { url?: string | null } | number | null;
     videoOrientation?: string | null;
     complete?: boolean | null;
     id?: string | null;
@@ -161,14 +161,22 @@ export default async function GuideServicePage({
   // Pre-render step content from Lexical JSON to HTML on the server.
   // This is necessary because GuideStep is a client component and cannot
   // use the server-only <RichText> component from Payload.
-  const stepsWithHtml = guideSteps.map((step, index) => ({
-    title: step.title,
-    id: sidebarSteps[index]!.id,
-    complete: step.complete ?? false,
-    video: step.video ?? null,
-    videoOrientation: step.videoOrientation ?? null,
-    contentHtml: lexicalToHtml(step.content),
-  }));
+  const stepsWithHtml = guideSteps.map((step, index) => {
+    // Resolve video URL from the media upload relationship
+    const videoUrl =
+      step.video && typeof step.video === "object" && "url" in step.video
+        ? (step.video.url ?? null)
+        : null;
+
+    return {
+      title: step.title,
+      id: sidebarSteps[index]!.id,
+      complete: step.complete ?? false,
+      video: videoUrl,
+      videoOrientation: step.videoOrientation ?? null,
+      contentHtml: lexicalToHtml(step.content),
+    };
+  });
 
   // Count steps that have the "complete" flag for progress tracking
   const completableStepCount = guideSteps.filter((s) => s.complete).length;
@@ -262,8 +270,6 @@ export default async function GuideServicePage({
                           guideId={guideId}
                           step={step}
                           stepNumber={index + 1}
-                          category={category}
-                          slug={service}
                         />
                       ))}
                     </div>

--- a/apps/website/collections/Guides.ts
+++ b/apps/website/collections/Guides.ts
@@ -162,9 +162,10 @@ export const Guides: CollectionConfig = {
                 },
                 {
                   name: "video",
-                  type: "text",
+                  type: "upload",
+                  relationTo: "media",
                   admin: {
-                    description: "Optional video URL for this step",
+                    description: "Optional video for this step",
                   },
                 },
                 {

--- a/apps/website/collections/Media.ts
+++ b/apps/website/collections/Media.ts
@@ -6,7 +6,7 @@ export const Media: CollectionConfig = {
     read: () => true,
   },
   upload: {
-    mimeTypes: ["image/*"],
+    mimeTypes: ["image/*", "video/*"],
   },
   fields: [
     {

--- a/apps/website/components/guides/GuideStep.tsx
+++ b/apps/website/components/guides/GuideStep.tsx
@@ -15,8 +15,6 @@ interface StepProps {
     contentHtml: string;
   };
   stepNumber: number;
-  category: string;
-  slug: string;
 }
 
 // Custom hook to determine if an element is visible in the viewport
@@ -68,31 +66,11 @@ export function GuideStep({
   guideId,
   step,
   stepNumber,
-  category,
-  slug,
 }: StepProps) {
   const { targetRef, videoRef } = useVideoIntersection();
   const isLandscapeVideo = step.videoOrientation === "landscape";
 
-  // github url: https://github.com/switch-to-eu/content/raw/refs/heads/main/nl/guides/email/gmail-to-protonmail/media/
-
-  // Format video URL to use the API route with full path
-  const getVideoUrl = (videoPath: string) => {
-    if (!videoPath) return "";
-
-    // If it's already an absolute URL, return as is
-    if (videoPath.startsWith("http")) {
-      return videoPath;
-    }
-
-    // If the video path already includes the guide path, use it as is
-    if (videoPath.includes(`guides/${category}/${slug}`)) {
-      return `https://github.com/switch-to-eu/content/raw/refs/heads/main/${videoPath}`;
-    }
-
-    // Otherwise, construct the full path including the guide location
-    return `https://github.com/switch-to-eu/content/raw/refs/heads/main/nl/guides/${category}/${slug}/${videoPath}`;
-  };
+  // Video URL comes directly from the media upload (Vercel Blob or local filesystem)
 
   // Render the step content
   const renderContent = () => (
@@ -133,7 +111,7 @@ export function GuideStep({
         loop
         controls
         className="w-full"
-        src={getVideoUrl(step.video as string)}
+        src={step.video as string}
         title={`Video guide for ${step.title}`}
       />
     </div>

--- a/apps/website/migrations/20260329_000000.ts
+++ b/apps/website/migrations/20260329_000000.ts
@@ -1,0 +1,39 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  // guides_steps: change video from varchar to integer FK pointing to media
+  await db.execute(sql`
+    ALTER TABLE "guides_steps" DROP COLUMN IF EXISTS "video";
+    ALTER TABLE "guides_steps" ADD COLUMN "video_id" integer;
+    ALTER TABLE "guides_steps" ADD CONSTRAINT "guides_steps_video_id_media_id_fk"
+      FOREIGN KEY ("video_id") REFERENCES "public"."media"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+    CREATE INDEX IF NOT EXISTS "guides_steps_video_idx" ON "guides_steps" USING btree ("video_id");
+  `)
+
+  // _guides_v_version_steps (versioned table): same change
+  await db.execute(sql`
+    ALTER TABLE "_guides_v_version_steps" DROP COLUMN IF EXISTS "video";
+    ALTER TABLE "_guides_v_version_steps" ADD COLUMN "video_id" integer;
+    ALTER TABLE "_guides_v_version_steps" ADD CONSTRAINT "_guides_v_version_steps_video_id_media_id_fk"
+      FOREIGN KEY ("video_id") REFERENCES "public"."media"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+    CREATE INDEX IF NOT EXISTS "_guides_v_version_steps_video_idx" ON "_guides_v_version_steps" USING btree ("video_id");
+  `)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  // Revert guides_steps
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "guides_steps_video_idx";
+    ALTER TABLE "guides_steps" DROP CONSTRAINT IF EXISTS "guides_steps_video_id_media_id_fk";
+    ALTER TABLE "guides_steps" DROP COLUMN IF EXISTS "video_id";
+    ALTER TABLE "guides_steps" ADD COLUMN "video" varchar;
+  `)
+
+  // Revert _guides_v_version_steps
+  await db.execute(sql`
+    DROP INDEX IF EXISTS "_guides_v_version_steps_video_idx";
+    ALTER TABLE "_guides_v_version_steps" DROP CONSTRAINT IF EXISTS "_guides_v_version_steps_video_id_media_id_fk";
+    ALTER TABLE "_guides_v_version_steps" DROP COLUMN IF EXISTS "video_id";
+    ALTER TABLE "_guides_v_version_steps" ADD COLUMN "video" varchar;
+  `)
+}

--- a/apps/website/migrations/index.ts
+++ b/apps/website/migrations/index.ts
@@ -1,6 +1,7 @@
 import * as migration_20260326_142357 from './20260326_142357';
 import * as migration_20260327_123528 from './20260327_123528';
 import * as migration_20260327_135230 from './20260327_135230';
+import * as migration_20260329_000000 from './20260329_000000';
 
 export const migrations = [
   {
@@ -17,5 +18,10 @@ export const migrations = [
     up: migration_20260327_135230.up,
     down: migration_20260327_135230.down,
     name: '20260327_135230'
+  },
+  {
+    up: migration_20260329_000000.up,
+    down: migration_20260329_000000.down,
+    name: '20260329_000000'
   },
 ];

--- a/apps/website/seed/importGuides.ts
+++ b/apps/website/seed/importGuides.ts
@@ -10,6 +10,7 @@ import {
   extractStepsWithMeta,
 } from "./content.js";
 import { markdownToLexical } from "./markdownToLexical.js";
+import { uploadMedia } from "./importMedia.js";
 
 export async function importGuides(
   payload: Payload | null,
@@ -51,15 +52,21 @@ export async function importGuides(
       : undefined;
 
     const enStepData = await Promise.all(
-      enSteps.map(async (step) => ({
-        title: step.title ?? "",
-        content: step.content
-          ? await markdownToLexical(step.content)
-          : undefined,
-        video: step.video ?? "",
-        videoOrientation: step.videooriantation ?? "landscape",
-        complete: step.complete ?? false,
-      })),
+      enSteps.map(async (step) => {
+        let videoId: number | undefined;
+        if (!dryRun && step.video && payload) {
+          videoId = await uploadMedia(payload, step.video, `${enFm.title} — ${step.title ?? "step"}`);
+        }
+        return {
+          title: step.title ?? "",
+          content: step.content
+            ? await markdownToLexical(step.content)
+            : undefined,
+          ...(videoId ? { video: videoId } : {}),
+          videoOrientation: step.videooriantation ?? "landscape",
+          complete: step.complete ?? false,
+        };
+      }),
     );
 
     const categoryId = categoryMap.get(guide.category);
@@ -133,15 +140,21 @@ export async function importGuides(
         : [];
 
       const nlStepData = await Promise.all(
-        nlSteps.map(async (step) => ({
-          title: step.title ?? "",
-          content: step.content
-            ? await markdownToLexical(step.content)
-            : undefined,
-          video: step.video ?? "",
-          videoOrientation: step.videooriantation ?? "landscape",
-          complete: step.complete ?? false,
-        })),
+        nlSteps.map(async (step) => {
+          let videoId: number | undefined;
+          if (step.video && payload) {
+            videoId = await uploadMedia(payload, step.video, `${nlFm.title} — ${step.title ?? "step"}`);
+          }
+          return {
+            title: step.title ?? "",
+            content: step.content
+              ? await markdownToLexical(step.content)
+              : undefined,
+            ...(videoId ? { video: videoId } : {}),
+            videoOrientation: step.videooriantation ?? "landscape",
+            complete: step.complete ?? false,
+          };
+        }),
       );
 
       await payload!.update({

--- a/apps/website/seed/importMedia.ts
+++ b/apps/website/seed/importMedia.ts
@@ -1,0 +1,134 @@
+/**
+ * Seed helper for uploading media (images and videos) to Payload CMS.
+ *
+ * Handles both local file paths (relative to the content directory) and
+ * external URLs. Uploaded files go through Payload's media collection,
+ * which routes to Vercel Blob in production or local filesystem in dev.
+ *
+ * Maintains a cache to avoid re-uploading the same source file.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { Payload } from "payload";
+
+const CONTENT_ROOT = path.resolve(
+  process.cwd(),
+  "../../packages/content/content",
+);
+
+/** Map from source path/URL to Payload media document ID */
+const mediaCache = new Map<string, number>();
+
+/**
+ * Guess MIME type from file extension.
+ */
+function getMimeType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".avif": "image/avif",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+    ".mov": "video/quicktime",
+    ".ogg": "video/ogg",
+  };
+  return mimeTypes[ext] ?? "application/octet-stream";
+}
+
+/**
+ * Resolve a media source string to a Buffer and filename.
+ *
+ * - If the source starts with http:// or https://, it is fetched.
+ * - Otherwise it is treated as a path relative to the content directory.
+ */
+async function resolveMedia(
+  source: string,
+): Promise<{ data: Buffer; name: string; mimeType: string } | null> {
+  if (source.startsWith("http://") || source.startsWith("https://")) {
+    try {
+      const response = await fetch(source);
+      if (!response.ok) {
+        console.warn(`    Failed to fetch media URL: ${source} (${response.status})`);
+        return null;
+      }
+      const buffer = Buffer.from(await response.arrayBuffer());
+      const urlPath = new URL(source).pathname;
+      const name = path.basename(urlPath) || "download";
+      const contentType = response.headers.get("content-type");
+      const mimeType = contentType?.split(";")[0]?.trim() ?? getMimeType(name);
+      return { data: buffer, name, mimeType };
+    } catch (err) {
+      console.warn(`    Failed to fetch media URL: ${source}`, err);
+      return null;
+    }
+  }
+
+  // Local file path — resolve relative to content root
+  const filePath = path.resolve(CONTENT_ROOT, source);
+  if (!fs.existsSync(filePath)) {
+    console.warn(`    Media file not found: ${filePath}`);
+    return null;
+  }
+
+  const data = fs.readFileSync(filePath);
+  const name = path.basename(filePath);
+  const mimeType = getMimeType(filePath);
+  return { data: Buffer.from(data), name, mimeType };
+}
+
+/**
+ * Upload a single media file to Payload and return its document ID.
+ *
+ * @param payload - Payload instance
+ * @param source - File path (relative to content dir) or URL
+ * @param alt - Alt text for the media
+ * @returns Media document ID, or undefined if upload failed
+ */
+export async function uploadMedia(
+  payload: Payload,
+  source: string,
+  alt = "",
+): Promise<number | undefined> {
+  if (!source) return undefined;
+
+  // Check cache first
+  const cached = mediaCache.get(source);
+  if (cached) return cached;
+
+  const resolved = await resolveMedia(source);
+  if (!resolved) return undefined;
+
+  try {
+    const doc = await payload.create({
+      collection: "media",
+      data: { alt },
+      file: {
+        data: resolved.data,
+        mimetype: resolved.mimeType,
+        name: resolved.name,
+        size: resolved.data.length,
+      },
+    });
+
+    const id = doc.id;
+    mediaCache.set(source, id);
+    console.log(`    Uploaded media: ${resolved.name} (id: ${id})`);
+    return id;
+  } catch (err) {
+    console.warn(`    Failed to upload media: ${source}`, err);
+    return undefined;
+  }
+}
+
+/**
+ * Clear the media cache. Called when resetting the database.
+ */
+export function clearMediaCache(): void {
+  mediaCache.clear();
+}

--- a/apps/website/seed/importServices.ts
+++ b/apps/website/seed/importServices.ts
@@ -9,6 +9,7 @@ import {
   getServiceBySlug,
 } from "./content.js";
 import { markdownToLexical } from "./markdownToLexical.js";
+import { uploadMedia } from "./importMedia.js";
 
 export async function importServices(
   payload: Payload | null,
@@ -60,8 +61,23 @@ export async function importServices(
     if (dryRun) {
       const fakeId = serviceMap.size + 1;
       serviceMap.set(slug, fakeId);
-      console.log(`  [dry-run] Service: ${slug} — "${enData.name}" (${enData.region}, category: ${categorySlug}${categoryId ? "" : " NOT FOUND"}, features: ${features.length}, nl: ${nlService ? "yes" : "no"})`);
+      console.log(`  [dry-run] Service: ${slug} — "${enData.name}" (${enData.region}, category: ${categorySlug}${categoryId ? "" : " NOT FOUND"}, features: ${features.length}, logo: ${enData.logo ? "yes" : "no"}, screenshot: ${enData.screenshot ? "yes" : "no"}, nl: ${nlService ? "yes" : "no"})`);
       continue;
+    }
+
+    // Upload logo and screenshot if present in frontmatter
+    let logoId: number | undefined;
+    let screenshotId: number | undefined;
+
+    if (enData.logo) {
+      logoId = await uploadMedia(payload!, enData.logo, `${enData.name} logo`);
+    }
+    if (enData.screenshot) {
+      screenshotId = await uploadMedia(
+        payload!,
+        enData.screenshot,
+        `${enData.name} screenshot`,
+      );
     }
 
     const created = await payload!.create({
@@ -87,6 +103,8 @@ export async function importServices(
         tags,
         content: enLexical,
         issues,
+        ...(logoId ? { logo: logoId } : {}),
+        ...(screenshotId ? { screenshot: screenshotId } : {}),
       },
     });
 

--- a/apps/website/seed/index.ts
+++ b/apps/website/seed/index.ts
@@ -22,6 +22,7 @@ import { importServices } from "./importServices.js";
 import { importGuides } from "./importGuides.js";
 import { importLandingPages } from "./importLandingPages.js";
 import { importPages } from "./importPages.js";
+import { clearMediaCache } from "./importMedia.js";
 
 const dryRun = process.argv.includes("--dry-run");
 
@@ -43,6 +44,7 @@ async function seed() {
       await payload.delete({ collection: "services", where: deleteAll });
       await payload.delete({ collection: "categories", where: deleteAll });
       await payload.delete({ collection: "media", where: deleteAll });
+      clearMediaCache();
       console.log("Database cleared.");
     }
   } else {


### PR DESCRIPTION
- Install Payload CMS dependencies (payload, @payloadcms/next,
  @payloadcms/db-postgres, @payloadcms/richtext-lexical,
  @payloadcms/translations, @payloadcms/storage-vercel-blob)
- Create payload.config.ts with Postgres adapter, Lexical editor,
  en/nl localization, and stub Categories/Media collections
- Create lib/payload.ts helper for getPayload() access
- Update next.config.ts: replace withMDX with withPayload, remove
  output: "standalone", remove content rewrite/CORS rules
- Add @payload-config path alias to tsconfig.json
- Split app into (frontend) and (payload) route groups
- Move all [locale] routes into (frontend)/[locale]
- Create Payload admin panel at /admin with RootPage/NotFoundPage
- Create Payload REST API catch-all at (payload)/api/[...slug]
- Update proxy.ts middleware to exclude /admin from i18n
- Add next override to prevent duplicate Next.js type resolution

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>