### PR TITLE
Add bulk content pipeline skills and pipeline status tracking

### DIFF
--- a/.claude/skills/bulk-humanize/SKILL.md
+++ b/.claude/skills/bulk-humanize/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: bulk-humanize
+description: Strip AI writing patterns from multiple services or guides in parallel. Use when asked to "humanize all", "bulk humanize", "de-AI all content", or clean up writing across many items at once.
+argument-hint: "'service <name1>, <name2>, ...' or 'service all' or 'guide all'"
+---
+
+# Bulk Humanize Skill
+
+Humanize content for multiple services or guides in parallel by dispatching one subagent per item.
+
+## Argument parsing
+
+| Argument | Meaning |
+|----------|---------|
+| `service ProtonMail, Tutanota` | Humanize these specific services |
+| `service all` | Humanize all services that have content |
+| `guide all` | Humanize all guides that have content |
+| `guide gmail-to-protonmail, outlook-to-tutanota` | Humanize specific guides by slug |
+
+## Process
+
+### Step 1: Build the item list
+
+**For `service all`:**
+```json
+mcp__payload__findServices: {"limit": 100, "depth": 0}
+```
+Filter client-side for services where `content` is not null/empty.
+
+**For `guide all`:**
+```json
+mcp__payload__findGuides: {"limit": 100, "depth": 0}
+```
+Filter for guides where `intro` is not null/empty.
+
+### Step 2: Confirm with user
+
+Show the list and count. Ask for confirmation.
+
+### Step 3: Dispatch parallel humanize agents
+
+**Agent prompt template for services:**
+
+```
+You are humanizing the content for service "{SERVICE_NAME}" on switch-to.eu.
+
+Use the /humanize skill. Process:
+
+1. Fetch the service:
+   mcp__payload__findServices: {"where": "{\"name\": {\"contains\": \"{SERVICE_NAME}\"}}", "limit": 1}
+   Get: description, content, features, issues
+
+2. Run the AI Pattern Detection on all text fields. Check for these 18 patterns:
+
+   Structural: rule of three lists, parallel sentence openings, symmetric paragraphs, formulaic transitions, setup-punchline
+   Word-level: inflated vocab (utilize→use, leverage→use, comprehensive→[specifics]), hedging clusters, vague intensifiers, AI-favorite words (delve, landscape, paradigm, ecosystem, seamless, cutting-edge), promotional adjectives
+   Tone: excessive enthusiasm, false certainty, anthropomorphization, reader flattery, empty empathy
+   Punctuation: em dashes (zero allowed), semicolons (zero allowed), ellipses for drama
+
+3. First pass: Rewrite all flagged text. Shorter sentences. Specific details. Varied sentence length. Natural contractions.
+
+4. Second pass: Audit the rewrite. Fix remaining AI-sounding patterns. Add one short paragraph if all paragraphs are same length. Vary sentence structure.
+
+5. Save changed fields via mcp__payload__updateServices.
+
+Return: service name, patterns found count by category, fields updated.
+```
+
+**Agent prompt template for guides:**
+
+```
+You are humanizing the guide "{GUIDE_SLUG}" on switch-to.eu.
+
+Use the /humanize skill. Same 18-pattern detection and two-pass rewrite process.
+
+1. Fetch via mcp__payload__findGuides: {"where": "{\"slug\": {\"equals\": \"{GUIDE_SLUG}\"}}", "limit": 1}
+   Get: intro, beforeYouStart, steps (each step's content), troubleshooting, outro
+
+2. Apply pattern detection and two-pass rewrite to every text field.
+
+3. Save changed fields via mcp__payload__updateGuides.
+
+Return: guide slug, patterns found count by category, fields updated.
+```
+
+### Step 4: Collect and report
+
+```
+## Bulk Humanize Complete
+
+Humanized: X/Y items
+
+| Item | Patterns Found | Patterns Fixed | Remaining |
+|------|---------------|----------------|-----------|
+| ProtonMail | 8 | 8 | 0 |
+| Tutanota | 5 | 4 | 1 (review manually) |
+| ... | ... | ... | ... |
+
+Most common patterns across all items:
+1. [pattern] — found X times
+2. [pattern] — found X times
+```
+
+## Guardrails
+
+- **Max parallel agents:** 10 at a time.
+- **Content required:** Skip items without content. Report them.
+- **Only update changed fields.** Don't save a field if it didn't change.

--- a/.claude/skills/bulk-research/SKILL.md
+++ b/.claude/skills/bulk-research/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: bulk-research
+description: Research multiple services in parallel using subagents. Use when asked to "research all services", "bulk research", "research these services", or need to populate Research tabs for many services at once.
+argument-hint: "'<name1>, <name2>, ...' or 'all' or 'category <name>' or 'unresearched'"
+---
+
+# Bulk Research Skill
+
+Research multiple services in parallel by dispatching one subagent per service.
+
+## Argument parsing
+
+| Argument | Meaning |
+|----------|---------|
+| `ProtonMail, Tutanota, Mailbox.org` | Research these specific services |
+| `all` | Research every service in Payload |
+| `unresearched` | Research services where `researchStatus` is "not-started" |
+| `category Email` | Research all services in the Email category |
+| `needs-update` | Research services where `researchStatus` is "needs-update" |
+
+## Process
+
+### Step 1: Build the service list
+
+Based on the argument, query Payload to get the list of services to research.
+
+**For specific names:** Split the comma-separated argument and trim whitespace.
+
+**For `all`:**
+```json
+mcp__payload__findServices: {"limit": 100, "depth": 0}
+```
+
+**For `unresearched`:**
+```json
+mcp__payload__findServices: {"where": "{\"researchStatus\": {\"equals\": \"not-started\"}}", "limit": 100}
+```
+
+**For `needs-update`:**
+```json
+mcp__payload__findServices: {"where": "{\"researchStatus\": {\"equals\": \"needs-update\"}}", "limit": 100}
+```
+
+**For `category X`:**
+First find the category ID, then query services:
+```json
+mcp__payload__findServices: {"where": "{\"category\": {\"equals\": CATEGORY_ID}}", "limit": 100}
+```
+
+### Step 2: Confirm with user
+
+Before dispatching agents, show the user:
+- Total number of services to research
+- List of service names
+- Ask for confirmation to proceed
+
+This prevents accidentally researching 100 services when the user meant 5.
+
+### Step 3: Dispatch parallel research agents
+
+Use the **Agent tool** to launch one subagent per service. All agents run in parallel.
+
+**Critical rules for parallel dispatch:**
+- Each agent gets a **complete, self-contained prompt** with all context it needs
+- Agents do NOT share state or read from each other
+- Each agent operates on a different service (no file conflicts)
+- Use `run_in_background: true` for all agents
+
+**Agent prompt template** (one per service):
+
+```
+You are researching the service "{SERVICE_NAME}" for switch-to.eu.
+
+Use the /research skill to research this service. Here is the full process:
+
+1. Find the service in Payload using mcp__payload__findServices with:
+   {"where": "{\"name\": {\"contains\": \"{SERVICE_NAME}\"}}", "limit": 5}
+
+2. Research using WebSearch and WebFetch:
+   - Company basics: website, headquarters, parent company, founded year, employees, open source
+   - Pricing: free tier, paid plans, enterprise, pricing page URL
+   - Privacy & GDPR: data storage locations, compliance status, DPA, privacy policy URL
+   - Security: certifications, breaches, audits
+   - Public sentiment: Reddit reviews, controversies
+
+3. Store findings via mcp__payload__updateServices with the service ID.
+   Map all fields: gdprCompliance, gdprNotes, privacyPolicyUrl, pricingDetails, pricingUrl,
+   headquarters, parentCompany, foundedYear, employeeCount, dataStorageLocations, certifications,
+   openSource, sourceCodeUrl, researchNotes (Lexical richText JSON), sourceUrls,
+   researchStatus: "complete", lastResearchedAt: today's ISO date.
+
+4. Also update General tab if empty: location, url, freeOption, startingPrice.
+
+Return a brief summary: service name, key findings, any gaps needing follow-up.
+```
+
+**Dispatch all agents in a single message** with multiple Agent tool calls. Use `subagent_type: "general-purpose"` and `run_in_background: true`.
+
+### Step 4: Collect results
+
+As agents complete, collect their summaries. When all are done, present a consolidated report:
+
+```
+## Bulk Research Complete
+
+Researched: X/Y services
+
+| Service | Status | Key Finding | Gaps |
+|---------|--------|-------------|------|
+| ProtonMail | Done | Swiss-based, GDPR compliant | None |
+| Tutanota | Done | German-based, open source | Employee count unknown |
+| ... | ... | ... | ... |
+
+Failed: [list any that failed with reasons]
+```
+
+## Guardrails
+
+- **Max parallel agents:** 10 at a time. If more than 10 services, batch them in groups of 10 and wait for each batch to complete before starting the next.
+- **Rate limiting:** The MCP server and web searches have rate limits. Batching in groups of 10 helps avoid hitting these.
+- **Error handling:** If an agent fails, note it in the report but don't retry automatically. The user can re-run individual failures with `/research`.

--- a/.claude/skills/bulk-seo-check/SKILL.md
+++ b/.claude/skills/bulk-seo-check/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: bulk-seo-check
+description: Run SEO audits on multiple services, guides, or pages in parallel. Use when asked to "SEO check all", "bulk SEO", "audit all services", or score SEO across many items at once.
+argument-hint: "'service all' or 'guide all' or 'service <name1>, <name2>, ...' or 'below <score>'"
+---
+
+# Bulk SEO Check Skill
+
+Run SEO audits on multiple items in parallel by dispatching one subagent per item.
+
+## Argument parsing
+
+| Argument | Meaning |
+|----------|---------|
+| `service ProtonMail, Tutanota` | SEO check these specific services |
+| `service all` | SEO check all services |
+| `guide all` | SEO check all guides |
+| `service below 70` | Re-check services with seoScore below 70 |
+| `service unchecked` | Check services that have never been SEO-reviewed |
+| `all` | Check everything (services + guides + pages) |
+
+## Process
+
+### Step 1: Build the item list
+
+**For `service unchecked`:**
+```json
+mcp__payload__findServices: {"where": "{\"lastSeoReviewAt\": {\"exists\": false}}", "limit": 100}
+```
+
+**For `service below 70`:**
+```json
+mcp__payload__findServices: {"where": "{\"seoScore\": {\"less_than\": 70}}", "limit": 100}
+```
+
+**For `all`:** Query services, guides, and pages separately. Combine the lists.
+
+### Step 2: Confirm with user
+
+Show count and list. Ask for confirmation.
+
+### Step 3: Dispatch parallel SEO audit agents
+
+**Agent prompt template:**
+
+```
+You are running an SEO audit on {COLLECTION_TYPE} "{ITEM_NAME}" for switch-to.eu.
+
+Use the /seo-check skill. Process:
+
+1. Fetch the item from Payload:
+   {FIND_TOOL}: {FIND_QUERY}
+
+2. Run the 10-point SEO checklist. Score each PASS (10), PARTIAL (5), FAIL (0):
+   1. Meta Title: present, 40-60 chars, contains keyword
+   2. Meta Description: present, 150-160 chars, value proposition
+   3. Keywords: 3-8 relevant keywords defined
+   4. Heading Structure: proper hierarchy, keyword in H2
+   5. Content Length: service 300+ words, guide 500+ words
+   6. Internal Context: category set, features 3+, tags 2+
+   7. Open Graph: ogTitle + ogDescription present and correct length
+   8. Image: screenshot or logo present
+   9. Readability: short paragraphs, active voice, Flesch 60+
+   10. Freshness: reviewed within 90 days
+
+3. Calculate total score (max 100).
+
+4. Save via {UPDATE_TOOL}:
+   - seoScore: [number]
+   - seoNotes: [formatted summary with PASS/ISSUES/suggestions]
+   - lastSeoReviewAt: [today ISO date]
+   - If metaTitle or metaDescription empty, populate with suggestions
+
+Return: item name, score, rating, top 3 issues.
+```
+
+### Step 4: Collect and report
+
+```
+## Bulk SEO Audit Complete
+
+Audited: X/Y items
+Average score: XX/100
+
+| Item | Type | Score | Rating | Top Issue |
+|------|------|-------|--------|-----------|
+| ProtonMail | Service | 85 | Good | Missing ogDescription |
+| Gmail | Service | 45 | Major issues | No meta fields |
+| ... | ... | ... | ... | ... |
+
+Score distribution:
+- Excellent (90-100): X items
+- Good (70-89): X items
+- Needs work (50-69): X items
+- Major issues (<50): X items
+
+Priority fixes (items scoring below 50):
+1. [item]: [what to fix]
+```
+
+## Guardrails
+
+- **Max parallel agents:** 10 at a time.
+- **Lightweight agents:** SEO checks don't use WebSearch, so they're fast. Can batch 10 comfortably.
+- **Auto-populate:** Empty metaTitle and metaDescription get filled with suggestions.

--- a/.claude/skills/bulk-translate/SKILL.md
+++ b/.claude/skills/bulk-translate/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: bulk-translate
+description: Translate multiple services or guides to another locale in parallel. Use when asked to "translate all", "bulk translate", "localize everything to Dutch", or translate many items at once.
+argument-hint: "'service all <locale>' or 'guide all <locale>' or 'service <name1>, <name2> <locale>' or 'untranslated <locale>'"
+---
+
+# Bulk Translate Skill
+
+Translate multiple items to a target locale in parallel by dispatching one subagent per item.
+
+## Argument parsing
+
+The last word is always the target locale (e.g. `nl`).
+
+| Argument | Meaning |
+|----------|---------|
+| `service ProtonMail, Tutanota nl` | Translate these services to Dutch |
+| `service all nl` | Translate all services to Dutch |
+| `guide all nl` | Translate all guides to Dutch |
+| `service untranslated nl` | Translate services missing Dutch content |
+| `all nl` | Translate all services + guides to Dutch |
+
+## Process
+
+### Step 1: Build the item list
+
+**For `service untranslated nl`:**
+Fetch all services, then for each check if the Dutch locale has content:
+```json
+mcp__payload__findServices: {"limit": 100, "locale": "nl"}
+```
+Filter for services where `description` or `name` is empty/matches English (not translated).
+
+**For `service all nl`:** Fetch all services regardless of translation status.
+
+### Step 2: Confirm with user
+
+Show count, list, and target locale. Ask for confirmation.
+
+### Step 3: Dispatch parallel translation agents
+
+**Agent prompt template for services:**
+
+```
+You are translating the service "{SERVICE_NAME}" to {LOCALE} for switch-to.eu.
+
+Use the /translate skill. Process:
+
+1. Fetch English content:
+   mcp__payload__findServices: {"where": "{\"name\": {\"contains\": \"{SERVICE_NAME}\"}}", "limit": 1, "locale": "en", "depth": 1}
+   Get: name, description, startingPrice, features, content, issues
+
+2. Translate all localized fields to {LOCALE}:
+   - Translate meaning, not words. Read naturally in the target language.
+   - Keep same tone: direct, practical, slightly opinionated.
+   - Do NOT translate: brand names, service names, technical terms (API, GDPR, URL).
+   - Dutch: use "je/jij" (informal), compound words as one word, short sentences, "data" singular/plural.
+   - Also translate SEO fields: metaTitle, metaDescription, ogTitle, ogDescription, keywords.
+
+3. Save via mcp__payload__updateServices with locale: "{LOCALE}".
+   Only send localized fields.
+
+Return: service name, locale, fields translated, any issues.
+```
+
+**Agent prompt template for guides:**
+
+```
+You are translating the guide "{GUIDE_SLUG}" to {LOCALE} for switch-to.eu.
+
+1. Fetch English: mcp__payload__findGuides by slug with locale: "en"
+   Get: title, description, intro, beforeYouStart, steps, troubleshooting, outro, missingFeatures
+
+2. Translate all localized fields following the same rules.
+
+3. Save via mcp__payload__updateGuides with locale: "{LOCALE}".
+
+Return: guide slug, locale, fields translated, any issues.
+```
+
+### Step 4: Collect and report
+
+```
+## Bulk Translation Complete
+
+Translated: X/Y items to {LOCALE}
+
+| Item | Type | Fields | Status | Notes |
+|------|------|--------|--------|-------|
+| ProtonMail | Service | 6 | Done | — |
+| Gmail to ProtonMail | Guide | 8 | Done | richText saved as plain text |
+| ... | ... | ... | ... | ... |
+
+Failed: [list with reasons]
+
+Next steps:
+- Review translations in Payload admin (/admin)
+- Run /bulk-seo-check to audit translated SEO fields
+- Run /bulk-humanize if translations read stiffly
+```
+
+## Guardrails
+
+- **Max parallel agents:** 10 at a time. Translation agents use LLM heavily, so keep batches reasonable.
+- **Locale validation:** Only proceed with supported locales (currently: nl). Reject unsupported locales.
+- **richText fields:** Translations may need to be saved as plain text if MCP rejects Lexical JSON. Note this in the report.
+- **No auto-publish.** All translations remain in their current draft/published status.

--- a/.claude/skills/bulk-write/SKILL.md
+++ b/.claude/skills/bulk-write/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: bulk-write
+description: Write content for multiple services or guides in parallel using subagents. Use when asked to "write all services", "bulk write", "write content for these services", or need to populate Content tabs for many services at once.
+argument-hint: "'service <name1>, <name2>, ...' or 'service all' or 'service unwritten' or 'guide all'"
+---
+
+# Bulk Write Skill
+
+Write content for multiple services or guides in parallel by dispatching one subagent per item.
+
+## Argument parsing
+
+| Argument | Meaning |
+|----------|---------|
+| `service ProtonMail, Tutanota` | Write content for these specific services |
+| `service all` | Write content for every service that has research completed |
+| `service unwritten` | Write content for services with research done but no content yet |
+| `service category Email` | Write content for all services in the Email category |
+| `guide all` | Write all guides that have both source and target services researched |
+
+## Process
+
+### Step 1: Build the item list
+
+**For `service unwritten`** — find services where research is complete but content is empty:
+```json
+mcp__payload__findServices: {"where": "{\"researchStatus\": {\"equals\": \"complete\"}}", "limit": 100, "depth": 1}
+```
+Then filter client-side for services where `content` is null/empty.
+
+**For `service all`** — same query but include all researched services regardless of content status.
+
+**For `guide all`:**
+```json
+mcp__payload__findGuides: {"limit": 100, "depth": 1}
+```
+Filter for guides where both sourceService and targetService have research complete.
+
+### Step 2: Confirm with user
+
+Show the list and count. Ask for confirmation. Note any services that lack research (these will be skipped with a warning).
+
+### Step 3: Dispatch parallel write agents
+
+Use the **Agent tool** to launch one subagent per item. All agents run in parallel.
+
+**Agent prompt template for services:**
+
+```
+You are writing content for the service "{SERVICE_NAME}" on switch-to.eu.
+
+Use the /write skill for service content. Here is the process:
+
+1. Fetch the service from Payload:
+   mcp__payload__findServices: {"where": "{\"name\": {\"contains\": \"{SERVICE_NAME}\"}}", "limit": 1, "depth": 1}
+
+2. Check that researchStatus is "complete". If not, return "SKIPPED: research not complete".
+
+3. Write these fields using the research data:
+   - description: 1-2 sentences, under 200 chars. What it is, where it's based, what matters.
+   - features: 4-6 short tags, 2-4 words each (pills on overview page)
+   - content: 150-250 words Lexical richText JSON. Opening → what's different → optional extras → "Worth knowing" h2
+   - pricingTiers: structured array from research pricing data
+   - For non-EU services: issues array with factual privacy concerns
+
+   Voice: knowledgeable friend, not marketing. Short sentences. Active voice. No em dashes, semicolons, jargon.
+   Consumer-friendly language: "only you can read your emails" not "zero-access encryption".
+   Always include "Worth knowing" section with honest trade-offs.
+
+4. Save via mcp__payload__updateServices with _status: "draft".
+
+Return: service name, word count, number of pricing tiers written, any issues.
+```
+
+**Agent prompt template for guides:**
+
+```
+You are writing a migration guide for switching from "{SOURCE}" to "{TARGET}" on switch-to.eu.
+
+Use the /write skill for guide content. Process:
+
+1. Fetch both services and the guide from Payload.
+2. Write: title, description, difficulty, timeRequired, intro (richText), beforeYouStart (richText),
+   steps array (4-8 steps with title + richText content), troubleshooting (richText),
+   outro (richText), missingFeatures array.
+3. Save via mcp__payload__updateGuides or mcp__payload__createGuides with _status: "draft".
+
+Return: guide title, step count, difficulty, any issues.
+```
+
+### Step 4: Collect and report
+
+```
+## Bulk Write Complete
+
+Written: X/Y items
+
+| Item | Type | Words | Status | Notes |
+|------|------|-------|--------|-------|
+| ProtonMail | Service | 220 | Done | 5 pricing tiers |
+| Gmail to ProtonMail | Guide | 650 | Done | 6 steps, beginner |
+| ... | ... | ... | ... | ... |
+
+Skipped (no research): [list]
+Failed: [list with reasons]
+```
+
+## Guardrails
+
+- **Max parallel agents:** 10 at a time. Batch larger sets.
+- **Research required:** Skip services without completed research. Report them.
+- **Draft status:** All content is saved as draft. Nothing publishes automatically.
+- **No overwrites without confirmation:** If content already exists, ask the user before overwriting.

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: pipeline
+description: Run the full content pipeline (write + humanize + SEO check) on one or more services or guides. Use when asked to "run the pipeline", "write and polish", "full content workflow", or "write + humanize + SEO". Runs steps sequentially per item, items in parallel.
+argument-hint: "'service <name>' or 'service <name1>, <name2>, ...' or 'service all' or 'guide <source> to <target>'"
+---
+
+# Content Pipeline Skill
+
+Run write → humanize → seo-check in sequence on one or more items. When processing multiple items, each item's pipeline runs as a parallel subagent.
+
+## What it does
+
+For each item, the pipeline runs three steps **in order**:
+1. **Write** — Generate content from research data (`/write`)
+2. **Humanize** — Strip AI patterns from the written content (`/humanize`)
+3. **Seo-check** — Audit and score the final content (`/seo-check`)
+
+Each step depends on the previous one completing. But different items are independent and run in parallel.
+
+## Argument parsing
+
+| Argument | Meaning |
+|----------|---------|
+| `service ProtonMail` | Full pipeline for one service |
+| `service ProtonMail, Tutanota, Mailbox.org` | Full pipeline for these services in parallel |
+| `service all` | Full pipeline for all services with completed research |
+| `service unwritten` | Pipeline for researched services that have no content yet |
+| `guide Gmail to ProtonMail` | Full pipeline for one guide |
+| `guide all` | Full pipeline for all guides |
+
+## Process
+
+### Step 1: Build the item list
+
+Same query logic as the bulk skills:
+
+**For `service all` / `service unwritten`:**
+```json
+mcp__payload__findServices: {"where": "{\"researchStatus\": {\"equals\": \"complete\"}}", "limit": 100, "depth": 0}
+```
+For `unwritten`, filter for services where `content` is null/empty.
+
+**For specific names:** Split comma-separated list, look up each.
+
+**For `guide all`:**
+```json
+mcp__payload__findGuides: {"limit": 100, "depth": 1}
+```
+
+### Step 2: Confirm with user
+
+Show:
+- Number of items
+- List of names
+- What will happen: "Each item gets: write → humanize → seo-check (sequential). Items run in parallel."
+- Estimated scope (3 MCP updates per item)
+
+Ask for confirmation.
+
+### Step 3: Update pipeline status
+
+For each service, update the `contentPipelineStatus` to "in-progress":
+```json
+mcp__payload__updateServices: {"contentPipelineStatus": "in-progress"}
+```
+
+### Step 4: Dispatch parallel pipeline agents
+
+Launch one subagent per item. Each agent runs the three steps **sequentially** within itself.
+
+**Agent prompt template for services:**
+
+```
+You are running the full content pipeline for service "{SERVICE_NAME}" on switch-to.eu.
+
+Run these three steps IN ORDER. Each step must complete before the next starts.
+
+## Step 1: Write (/write)
+
+1. Fetch the service:
+   mcp__payload__findServices: {"where": "{\"name\": {\"contains\": \"{SERVICE_NAME}\"}}", "limit": 1, "depth": 1}
+
+2. Verify researchStatus is "complete". If not, return "SKIPPED: research not complete".
+
+3. Write these fields using research data:
+   - description: 1-2 sentences, under 200 chars
+   - features: 4-6 short tags, 2-4 words each
+   - content: 150-250 words Lexical richText JSON (opening → what's different → worth knowing h2)
+   - pricingTiers: structured array from pricing research
+   - For non-EU: issues array with factual privacy concerns
+
+   Voice: knowledgeable friend. Short sentences. Active voice. No em dashes or semicolons.
+   Consumer-friendly: "only you can read your emails" not "zero-access encryption".
+   Always include "Worth knowing" section.
+
+4. Save via mcp__payload__updateServices with _status: "draft".
+
+## Step 2: Humanize (/humanize)
+
+1. Re-fetch the service to get the just-written content.
+
+2. Check all text fields for 18 AI patterns:
+   Structural: rule of three, parallel openings, symmetric paragraphs, formulaic transitions, setup-punchline
+   Word-level: inflated vocab, hedging, vague intensifiers, AI-favorite words, promotional adjectives
+   Tone: excessive enthusiasm, false certainty, anthropomorphization, reader flattery, empty empathy
+   Punctuation: em dashes (zero), semicolons (zero), ellipses
+
+3. First pass: rewrite flagged text. Shorter sentences, specific details, varied length, natural contractions.
+
+4. Second pass: audit for remaining AI feel. Fix.
+
+5. Save changed fields via mcp__payload__updateServices.
+
+## Step 3: SEO Check (/seo-check)
+
+1. Re-fetch the service to get humanized content.
+
+2. Run 10-point checklist (each: PASS 10, PARTIAL 5, FAIL 0):
+   Meta Title, Meta Description, Keywords, Heading Structure, Content Length,
+   Internal Context, Open Graph, Image, Readability, Freshness
+
+3. Calculate score (max 100).
+
+4. Save: seoScore, seoNotes, lastSeoReviewAt. Auto-populate empty metaTitle/metaDescription.
+
+5. Update contentPipelineStatus to "complete".
+
+## Return
+
+Return a summary:
+- Service name
+- Write: word count, pricing tiers count
+- Humanize: patterns found/fixed
+- SEO: score and rating
+- Any issues or gaps
+```
+
+**Agent prompt template for guides:**
+
+```
+You are running the full content pipeline for guide "{GUIDE_TITLE}" on switch-to.eu.
+
+Run these three steps IN ORDER:
+
+## Step 1: Write
+Fetch both source and target services. Write: title, description, difficulty, timeRequired,
+intro, beforeYouStart, steps (4-8), troubleshooting, outro, missingFeatures.
+Save with _status: "draft".
+
+## Step 2: Humanize
+Re-fetch guide. Apply 18-pattern detection + two-pass rewrite on all text fields
+(intro, beforeYouStart, step contents, troubleshooting, outro). Save changed fields.
+
+## Step 3: SEO Check
+Re-fetch guide. Run 10-point checklist. Save seoScore, seoNotes, lastSeoReviewAt.
+
+Return: guide title, step count, patterns found/fixed, SEO score.
+```
+
+### Step 5: Collect and report
+
+```
+## Content Pipeline Complete
+
+Processed: X/Y items (write → humanize → seo-check)
+
+| Item | Type | Words | AI Patterns Fixed | SEO Score | Status |
+|------|------|-------|-------------------|-----------|--------|
+| ProtonMail | Service | 220 | 6 | 85/100 | Complete |
+| Tutanota | Service | 195 | 3 | 78/100 | Complete |
+| ... | ... | ... | ... | ... | ... |
+
+Average SEO score: XX/100
+Total AI patterns fixed: XX
+
+Skipped (no research): [list]
+Failed: [list with reasons]
+
+Next steps:
+- Review all drafts in Payload admin (/admin)
+- Run /bulk-translate to localize completed content
+- Publish approved content
+```
+
+## Guardrails
+
+- **Max parallel agents:** 10 at a time. Each agent does 3 sequential steps, so they're heavier than single-skill agents.
+- **Research required:** Services without completed research are skipped.
+- **Sequential within each agent:** Write MUST complete before humanize. Humanize MUST complete before SEO check. This is enforced by the agent running steps in order.
+- **Draft status:** Everything saves as draft. No auto-publishing.
+- **Idempotent:** Running the pipeline twice on the same service overwrites the previous content. Confirm with user if content already exists.
+- **Pipeline status tracking:** The `contentPipelineStatus` field on services tracks progress. Values: not-started → in-progress → complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Search uses Fuse.js with in-memory caching (5-min TTL, keyed by locale).
 
 The site uses custom Claude Code skills wired to Payload CMS via MCP for a research-to-publish pipeline. All content enters as draft and requires human review before publishing.
 
-### Pipeline
+### Single-Item Pipeline
 
 ```
 /research "ServiceName"     → Fills Research tab on service via MCP
@@ -168,6 +168,23 @@ For guides:
 → Review Dutch + publish
 ```
 
+### Bulk Pipeline (Parallel Agents)
+
+```
+/bulk-research all                      → Research all unresearched services in parallel
+/bulk-write service all                 → Write content for all researched services in parallel
+/bulk-humanize service all              → Humanize all services with content in parallel
+/bulk-seo-check service all             → SEO audit all services in parallel
+/bulk-translate service all nl          → Translate all services to Dutch in parallel
+/pipeline service all                   → Run write→humanize→seo-check per service (parallel across items)
+```
+
+Bulk skills accept: specific names (comma-separated), `all`, `unresearched`/`unwritten`/`unchecked`, `category <name>`. Each dispatches one subagent per item using the Agent tool with `run_in_background: true`. Max 10 parallel agents per batch.
+
+### Content Pipeline Status
+
+Services and Guides have a `contentPipelineStatus` sidebar field tracking progress: `not-started` → `in-progress` → `written` → `humanized` → `seo-checked` → `translated` → `complete`. The `/pipeline` skill updates this automatically. Useful for filtering items that need the next step.
+
 ### Skills (`.claude/skills/`)
 
 | Skill | Type | Purpose |
@@ -178,6 +195,12 @@ For guides:
 | `humanize` | `/humanize` | Strip AI writing patterns |
 | `seo-check` | `/seo-check` | SEO audit with scoring |
 | `translate` | `/translate` | Localization to other EU languages |
+| `bulk-research` | `/bulk-research` | Parallel research via subagents |
+| `bulk-write` | `/bulk-write` | Parallel content writing via subagents |
+| `bulk-humanize` | `/bulk-humanize` | Parallel humanization via subagents |
+| `bulk-seo-check` | `/bulk-seo-check` | Parallel SEO audits via subagents |
+| `bulk-translate` | `/bulk-translate` | Parallel translation via subagents |
+| `pipeline` | `/pipeline` | Combined write→humanize→seo-check (sequential per item, parallel across items) |
 
 ### Tone rules (from informational-copy)
 

--- a/apps/website/collections/Guides.ts
+++ b/apps/website/collections/Guides.ts
@@ -61,6 +61,24 @@ export const Guides: CollectionConfig = {
       type: "date",
       admin: { position: "sidebar" },
     },
+    {
+      name: "contentPipelineStatus",
+      type: "select",
+      options: [
+        { label: "Not Started", value: "not-started" },
+        { label: "In Progress", value: "in-progress" },
+        { label: "Written", value: "written" },
+        { label: "Humanized", value: "humanized" },
+        { label: "SEO Checked", value: "seo-checked" },
+        { label: "Translated", value: "translated" },
+        { label: "Complete", value: "complete" },
+      ],
+      defaultValue: "not-started",
+      admin: {
+        position: "sidebar",
+        description: "Tracks progress through the content pipeline",
+      },
+    },
     // Tabs
     {
       type: "tabs",

--- a/apps/website/collections/Services.ts
+++ b/apps/website/collections/Services.ts
@@ -54,6 +54,24 @@ export const Services: CollectionConfig = {
       defaultValue: false,
       admin: { position: "sidebar" },
     },
+    {
+      name: "contentPipelineStatus",
+      type: "select",
+      options: [
+        { label: "Not Started", value: "not-started" },
+        { label: "In Progress", value: "in-progress" },
+        { label: "Written", value: "written" },
+        { label: "Humanized", value: "humanized" },
+        { label: "SEO Checked", value: "seo-checked" },
+        { label: "Translated", value: "translated" },
+        { label: "Complete", value: "complete" },
+      ],
+      defaultValue: "not-started",
+      admin: {
+        position: "sidebar",
+        description: "Tracks progress through the content pipeline (write → humanize → SEO → translate)",
+      },
+    },
     // Main content area — tabs
     {
       type: "tabs",


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive bulk content pipeline system with parallel agent dispatch capabilities, along with pipeline status tracking fields for Services and Guides. The changes enable efficient batch processing of research, writing, humanization, SEO audits, and translation workflows.

## Key Changes

**New Bulk Skills** (6 new skill definitions):
- `/bulk-research` — Research multiple services in parallel by dispatching one subagent per service
- `/bulk-write` — Write content for multiple services/guides in parallel
- `/bulk-humanize` — Strip AI patterns from multiple items in parallel
- `/bulk-seo-check` — Run SEO audits on multiple items in parallel
- `/bulk-translate` — Translate multiple items to a target locale in parallel
- `/pipeline` — Run the full write→humanize→seo-check sequence per item (items in parallel)

Each skill:
- Accepts flexible arguments: specific names (comma-separated), `all`, status filters (`unresearched`, `unwritten`, `unchecked`), or category filters
- Confirms with user before dispatching agents
- Dispatches up to 10 parallel subagents using the Agent tool with `run_in_background: true`
- Collects and reports results in a consolidated summary table
- Includes guardrails for rate limiting, error handling, and idempotency

**Pipeline Status Tracking**:
- Added `contentPipelineStatus` field to both Services and Guides collections
- Status values: `not-started` → `in-progress` → `written` → `humanized` → `seo-checked` → `translated` → `complete`
- Sidebar position for easy visibility during content work
- Helps track progress through the multi-step content workflow

**Documentation Updates**:
- Updated CLAUDE.md to document both single-item and bulk pipeline workflows
- Added examples of bulk skill usage and parallel agent dispatch patterns
- Clarified max 10 parallel agents per batch to respect rate limits

## Implementation Details

- All bulk skills follow a consistent 4-step pattern: build item list → confirm with user → dispatch parallel agents → collect and report
- Each subagent receives a complete, self-contained prompt with all context needed (no shared state)
- The `/pipeline` skill is unique in that each subagent runs 3 sequential steps (write→humanize→seo-check) internally, while different items run in parallel
- Bulk skills batch larger sets in groups of 10 to avoid hitting MCP server and web search rate limits
- All content saves as draft; no auto-publishing
- Idempotent design: running the pipeline twice overwrites previous content (with user confirmation if content exists)

https://claude.ai/code/session_013UcfAN5ts6Vb84vhKnzha5