### PR TITLE
fix: map eu-friendly region to /eu/ in search URLs

### DIFF
--- a/apps/website/app/api/search/featured/route.ts
+++ b/apps/website/app/api/search/featured/route.ts
@@ -53,10 +53,7 @@ export async function GET(request: NextRequest) {
         type: "service" as const,
         title: service.name,
         description: service.description,
-        url:
-          service.region === "eu"
-            ? `/services/${service.slug}`
-            : `/services/${service.region}/${service.slug}`,
+        url: `/services/${service.region === "non-eu" ? "non-eu" : "eu"}/${service.slug}`,
         region: service.region,
         category: categorySlug,
         location: service.location,

--- a/apps/website/app/api/search/route.ts
+++ b/apps/website/app/api/search/route.ts
@@ -85,10 +85,7 @@ export async function GET(request: NextRequest) {
               type: "service",
               title: service.name,
               description: service.description,
-              url:
-                service.region === "eu"
-                  ? `/services/${service.slug}`
-                  : `/services/${service.region}/${service.slug}`,
+              url: `/services/${service.region === "non-eu" ? "non-eu" : "eu"}/${service.slug}`,
               region: service.region,
               category: categorySlug,
               location: service.location,


### PR DESCRIPTION
## Summary
- eu-friendly services generated broken `/services/eu-friendly/` URLs in search results
- Fixed both `/api/search` and `/api/search/featured` to map `eu-friendly` → `eu` in the URL path, matching the pattern already used in `ServiceCard.tsx` and `sitemap.ts`

## Test plan
- [ ] Search for an eu-friendly service, click the result — should navigate to `/services/eu/{slug}`
- [ ] Verify featured services dropdown also links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inconsistent URL structure for services displayed in search results. Service URL paths now follow a unified format regardless of region, improving consistency and reliability of search result navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->