### PR TITLE
fix: use www.switch-to.eu as canonical domain across all apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A community-driven platform helping users switch from non-EU digital services to EU alternatives through clear, step-by-step migration guides.
 
-**Live Site**: [switch-to.eu](https://switch-to.eu)
+**Live Site**: [switch-to.eu](https://www.switch-to.eu)
 
 ## About
 

--- a/apps/kanban/app/[locale]/layout.tsx
+++ b/apps/kanban/app/[locale]/layout.tsx
@@ -132,12 +132,12 @@ export default async function LocaleLayout({
                 links={[
                   {
                     label: footerT('privacy'),
-                    href: 'https://switch-to.eu/privacy',
+                    href: 'https://www.switch-to.eu/privacy',
                     external: true,
                   },
                   {
                     label: footerT('terms'),
-                    href: 'https://switch-to.eu/terms',
+                    href: 'https://www.switch-to.eu/terms',
                     external: true,
                   },
                 ]}

--- a/apps/kanban/components/board-form.tsx
+++ b/apps/kanban/components/board-form.tsx
@@ -225,12 +225,12 @@ export function BoardForm() {
                 <span>
                   {t.rich("terms", {
                     terms: (chunks) => (
-                      <a href="https://switch-to.eu/terms" target="_blank" rel="noopener noreferrer" className="underline text-foreground hover:text-tool-primary">
+                      <a href="https://www.switch-to.eu/terms" target="_blank" rel="noopener noreferrer" className="underline text-foreground hover:text-tool-primary">
                         {chunks}
                       </a>
                     ),
                     privacy: (chunks) => (
-                      <a href="https://switch-to.eu/privacy" target="_blank" rel="noopener noreferrer" className="underline text-foreground hover:text-tool-primary">
+                      <a href="https://www.switch-to.eu/privacy" target="_blank" rel="noopener noreferrer" className="underline text-foreground hover:text-tool-primary">
                         {chunks}
                       </a>
                     ),

--- a/apps/keepfocus/app/[locale]/layout.tsx
+++ b/apps/keepfocus/app/[locale]/layout.tsx
@@ -108,12 +108,12 @@ export default async function LocaleLayout({
           links={[
             {
               label: footerT('privacy'),
-              href: 'https://switch-to.eu/privacy',
+              href: 'https://www.switch-to.eu/privacy',
               external: true,
             },
             {
               label: footerT('terms'),
-              href: 'https://switch-to.eu/terms',
+              href: 'https://www.switch-to.eu/terms',
               external: true,
             },
           ]}

--- a/apps/keepfocus/app/[locale]/privacy/page.tsx
+++ b/apps/keepfocus/app/[locale]/privacy/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function PrivacyPage() {
-  redirect("https://switch-to.eu/privacy");
+  redirect("https://www.switch-to.eu/privacy");
 }

--- a/apps/keepfocus/app/llm.txt/route.ts
+++ b/apps/keepfocus/app/llm.txt/route.ts
@@ -6,7 +6,7 @@ export async function GET() {
 KeepFocus helps you stay productive using the Pomodoro Technique: 25-minute work sessions followed by 5-minute breaks. All data stays in your browser.
 
 - **URL**: https://focus.switch-to.eu
-- **Part of**: [switch-to.eu](https://switch-to.eu) — European alternatives to Big Tech
+- **Part of**: [switch-to.eu](https://www.switch-to.eu) — European alternatives to Big Tech
 - **Privacy**: No accounts, no tracking, no server-side data storage. Everything runs locally in the browser.
 - **Locales**: English (en), Dutch (nl)
 

--- a/apps/keepfocus/e2e/smoke.spec.ts
+++ b/apps/keepfocus/e2e/smoke.spec.ts
@@ -24,4 +24,4 @@ for (const locale of locales) {
   });
 }
 
-// Privacy page redirects to external https://switch-to.eu/privacy — skip smoke test
+// Privacy page redirects to external https://www.switch-to.eu/privacy — skip smoke test

--- a/apps/listy/app/llm.txt/route.ts
+++ b/apps/listy/app/llm.txt/route.ts
@@ -6,7 +6,7 @@ export async function GET() {
 Listy lets you create and share lists instantly — shopping lists, potlucks, and more. List data is encrypted so the server never sees your content.
 
 - **URL**: https://list.switch-to.eu
-- **Part of**: [switch-to.eu](https://switch-to.eu) — European alternatives to Big Tech
+- **Part of**: [switch-to.eu](https://www.switch-to.eu) — European alternatives to Big Tech
 - **Privacy**: End-to-end encrypted. Encryption key stays in the URL fragment (never sent to the server). No accounts, no tracking.
 - **Data storage**: Redis with configurable expiration. All list data is encrypted at rest.
 - **Locales**: English (en), Dutch (nl)

--- a/apps/plotty/app/llm.txt/route.ts
+++ b/apps/plotty/app/llm.txt/route.ts
@@ -6,7 +6,7 @@ export async function GET() {
 Plotty lets you create polls and find the best time to meet. Poll data is encrypted — the server never sees your content in plain text.
 
 - **URL**: https://poll.switch-to.eu
-- **Part of**: [switch-to.eu](https://switch-to.eu) — European alternatives to Big Tech
+- **Part of**: [switch-to.eu](https://www.switch-to.eu) — European alternatives to Big Tech
 - **Privacy**: End-to-end encrypted. Encryption key stays in the URL fragment (never sent to the server). No accounts, no tracking.
 - **Data storage**: Redis with configurable expiration. All poll data is encrypted at rest.
 - **Locales**: English (en), Dutch (nl)

--- a/apps/privnote/app/llm.txt/route.ts
+++ b/apps/privnote/app/llm.txt/route.ts
@@ -6,7 +6,7 @@ export async function GET() {
 PrivNote lets you send private notes that self-destruct after reading. Notes are end-to-end encrypted — the server never sees your content in plain text.
 
 - **URL**: https://privnote.switch-to.eu
-- **Part of**: [switch-to.eu](https://switch-to.eu) — European alternatives to Big Tech
+- **Part of**: [switch-to.eu](https://www.switch-to.eu) — European alternatives to Big Tech
 - **Privacy**: End-to-end encrypted. Encryption key stays in the URL fragment (never sent to the server). No accounts, no tracking.
 - **Data storage**: Redis with configurable TTL (5 minutes to 30 days). All note data is encrypted at rest.
 - **Locales**: English (en), Dutch (nl)

--- a/apps/privnote/components/create-note-form.tsx
+++ b/apps/privnote/components/create-note-form.tsx
@@ -218,7 +218,7 @@ export function CreateNoteForm() {
                   {t.rich("termsLabel", {
                     privacy: (chunks) => (
                       <a
-                        href="https://switch-to.eu/privacy"
+                        href="https://www.switch-to.eu/privacy"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-tool-primary hover:underline"
@@ -228,7 +228,7 @@ export function CreateNoteForm() {
                     ),
                     terms: (chunks) => (
                       <a
-                        href="https://switch-to.eu/terms"
+                        href="https://www.switch-to.eu/terms"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-tool-primary hover:underline"

--- a/apps/website-tool/app/[locale]/layout.tsx
+++ b/apps/website-tool/app/[locale]/layout.tsx
@@ -123,12 +123,12 @@ export default async function LocaleLayout({
             links={[
               {
                 label: footerT("privacy"),
-                href: "https://switch-to.eu/privacy",
+                href: "https://www.switch-to.eu/privacy",
                 external: true,
               },
               {
                 label: footerT("terms"),
-                href: "https://switch-to.eu/terms",
+                href: "https://www.switch-to.eu/terms",
                 external: true,
               },
             ]}

--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -88,7 +88,7 @@ export async function generateMetadata({
       ? guide.targetService.name
       : String(guide.targetService ?? "");
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://switch-to.eu";
+  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
   const path = `/guides/${category}/${service}`;
   const title = guide.metaTitle || t("title", { title: guide.title });
   const description = guide.metaDescription || guide.description;
@@ -202,7 +202,7 @@ export default async function GuideServicePage({
   const outroHtml = lexicalToHtml(guide.outro as SerializedEditorState | null);
 
   // HowTo JSON-LD structured data
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://switch-to.eu";
+  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
   const howToJsonLd = {
     "@context": "https://schema.org",
     "@type": "HowTo",

--- a/apps/website/app/(frontend)/[locale]/layout.tsx
+++ b/apps/website/app/(frontend)/[locale]/layout.tsx
@@ -69,7 +69,7 @@ export default async function LocaleLayout({
 }>) {
   await params;
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://switch-to.eu";
+  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
 
   const organizationJsonLd = {
     "@context": "https://schema.org",
@@ -96,7 +96,7 @@ export default async function LocaleLayout({
   };
 
   return (
-    <PlausibleProvider domain="switch-to.eu">
+    <PlausibleProvider domain="www.switch-to.eu">
       <NextIntlClientProvider>
         <script
           type="application/ld+json"

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -40,7 +40,7 @@ export async function generateMetadata({
     categoryData?.description ||
     `EU-based alternatives for common ${category} services that prioritize privacy and data protection.`;
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://switch-to.eu";
+  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
   const path = `/services/${category}`;
   const title = categoryData?.metaTitle || `${pageTitle} | switch-to.eu`;
   const description = categoryData?.metaDescription || pageDescription;

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
@@ -61,7 +61,7 @@ export async function generateMetadata({
 
   if (!euService || !nonEuService) return { title: "Not Found" };
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://switch-to.eu";
+  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
   const path = `/services/eu/${service_name}/vs-${slug}`;
   const title = `${euService.name} vs ${nonEuService.name} | switch-to.eu`;
   const description = `Compare ${euService.name} and ${nonEuService.name}. See how the EU alternative stacks up on privacy, pricing, and features.`;

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -67,7 +67,7 @@ export async function generateMetadata({
 
   const tags = (service.tags ?? []).map((t) => t.tag);
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://switch-to.eu";
+  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
   const path = `/services/non-eu/${service_name}`;
   const title = service.metaTitle || `${service.name} | switch-to.eu`;
   const description = service.metaDescription || service.description;

--- a/apps/website/app/llms.txt/route.ts
+++ b/apps/website/app/llms.txt/route.ts
@@ -9,7 +9,6 @@ const getCachedIndex = unstable_cache(
       payload.find({
         collection: "categories",
         locale: "en",
-        limit: 0,
         pagination: false,
         depth: 0,
       }),
@@ -17,7 +16,6 @@ const getCachedIndex = unstable_cache(
         collection: "services",
         where: { _status: { equals: "published" } },
         locale: "en",
-        limit: 0,
         pagination: false,
         depth: 1,
       }),
@@ -25,7 +23,6 @@ const getCachedIndex = unstable_cache(
         collection: "guides",
         where: { _status: { equals: "published" } },
         locale: "en",
-        limit: 0,
         pagination: false,
         depth: 1,
       }),

--- a/apps/website/app/robots.ts
+++ b/apps/website/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_URL!;
+  const baseUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
   return {
     rules: {
       userAgent: "*",

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -1,10 +1,10 @@
 import type { MetadataRoute } from "next";
 import { getPayload } from "@/lib/payload";
-import type { Service, Guide, Category } from "@/payload-types";
+import type { Service, Guide, Category, LandingPage } from "@/payload-types";
 import { routing } from "@switch-to-eu/i18n/routing";
 import { unstable_noStore as noStore } from "next/cache";
 
-const baseUrl = process.env.NEXT_PUBLIC_URL!;
+const baseUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
 const { locales } = routing;
 
 export const dynamic = "force-dynamic";
@@ -25,9 +25,12 @@ const staticRoutes = [
  */
 function localeAlternates(path: string) {
   return {
-    languages: Object.fromEntries(
-      locales.map((l) => [l, `${baseUrl}/${l}${path}`])
-    ),
+    languages: {
+      "x-default": `${baseUrl}/en${path}`,
+      ...Object.fromEntries(
+        locales.map((l) => [l, `${baseUrl}/${l}${path}`])
+      ),
+    },
   };
 }
 
@@ -57,43 +60,48 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   );
 
   // Fetch all content in parallel
-  const [categoriesResult, servicesResult, guidesResult] = await Promise.all([
-    payload.find({
-      collection: "categories",
-      locale: "all",
-      limit: 0,
-      pagination: false,
-    }),
-    payload.find({
-      collection: "services",
-      where: { _status: { equals: "published" } },
-      locale: "all",
-      limit: 0,
-      pagination: false,
-    }),
-    payload.find({
-      collection: "guides",
-      where: { _status: { equals: "published" } },
-      locale: "all",
-      limit: 0,
-      pagination: false,
-      depth: 1,
-    }),
-  ]);
+  // NOTE: Do NOT pass limit: 0 — Payload v3.80+ treats it as "return 0 docs".
+  // pagination: false alone returns every document in the collection.
+  const [categoriesResult, servicesResult, guidesResult, landingPagesResult] =
+    await Promise.all([
+      payload.find({
+        collection: "categories",
+        locale: "all",
+        pagination: false,
+      }),
+      payload.find({
+        collection: "services",
+        where: { _status: { equals: "published" } },
+        locale: "all",
+        pagination: false,
+      }),
+      payload.find({
+        collection: "guides",
+        where: { _status: { equals: "published" } },
+        locale: "all",
+        pagination: false,
+        depth: 1,
+      }),
+      payload.find({
+        collection: "landing-pages",
+        where: { _status: { equals: "published" } },
+        locale: "all",
+        pagination: false,
+      }),
+    ]);
 
   // Categories — one entry per locale
-  const categoriesEntries: MetadataRoute.Sitemap = categoriesResult.docs.flatMap(
-    (category: Category) => {
+  const categoriesEntries: MetadataRoute.Sitemap =
+    categoriesResult.docs.flatMap((category: Category) => {
       const path = `/services/${category.slug}`;
       return locales.map((locale) => ({
         url: `${baseUrl}/${locale}${path}`,
         lastModified: new Date(category.updatedAt),
         changeFrequency: "weekly" as const,
-        priority: 0.7,
+        priority: 0.8,
         alternates: localeAlternates(path),
       }));
-    }
-  );
+    });
 
   // Services — one entry per locale, plus pricing/security subpages
   const servicesEntries: MetadataRoute.Sitemap = servicesResult.docs.flatMap(
@@ -106,11 +114,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         url: `${baseUrl}/${locale}${serviceUrl}`,
         lastModified: lastMod,
         changeFrequency: "monthly" as const,
-        priority: 0.6,
+        priority: 0.7,
         alternates: localeAlternates(serviceUrl),
       }));
 
-      // Pricing subpage
+      // Pricing subpage (EU services only)
       if (
         regionPath === "eu" &&
         ((service.pricingTiers && service.pricingTiers.length > 0) ||
@@ -129,7 +137,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         );
       }
 
-      // Security subpage
+      // Security subpage (EU services only)
       if (
         regionPath === "eu" &&
         (service.gdprCompliance ||
@@ -185,11 +193,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         url: `${baseUrl}/${locale}${path}`,
         lastModified: new Date(guide.updatedAt),
         changeFrequency: "monthly" as const,
-        priority: 0.6,
+        priority: 0.9,
         alternates: localeAlternates(path),
       }));
     }
   );
+
+  // Landing pages — one entry per locale
+  const landingPageEntries: MetadataRoute.Sitemap =
+    landingPagesResult.docs.flatMap((page: LandingPage) => {
+      const path = `/pages/${page.slug}`;
+      return locales.map((locale) => ({
+        url: `${baseUrl}/${locale}${path}`,
+        lastModified: new Date(page.updatedAt),
+        changeFrequency: "monthly" as const,
+        priority: 0.6,
+        alternates: localeAlternates(path),
+      }));
+    });
 
   return [
     ...homeEntries,
@@ -198,5 +219,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...servicesEntries,
     ...comparisonEntries,
     ...guidesEntries,
+    ...landingPageEntries,
   ];
 }

--- a/apps/website/lib/llm-content.ts
+++ b/apps/website/lib/llm-content.ts
@@ -7,7 +7,7 @@ import type { Service, Guide, Category } from "@/payload-types";
 import { lexicalToMarkdown } from "./lexical-to-markdown";
 import { getGdprLabel } from "./services";
 
-const BASE_URL = process.env.NEXT_PUBLIC_URL ?? "https://switch-to.eu";
+const BASE_URL = process.env.NEXT_PUBLIC_URL ?? "https://www.switch-to.eu";
 
 // ---------------------------------------------------------------------------
 // Service → Markdown

--- a/apps/website/lib/service-metadata.ts
+++ b/apps/website/lib/service-metadata.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getServiceBySlug, getCategorySlug } from "@/lib/services";
 
-const siteUrl = process.env.NEXT_PUBLIC_URL || "https://switch-to.eu";
+const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
 
 export async function generateServiceMetadata({
   serviceName,

--- a/packages/blocks/src/components/brand-indicator.tsx
+++ b/packages/blocks/src/components/brand-indicator.tsx
@@ -18,7 +18,7 @@ export function BrandIndicator({
   showIcon = false,
   asSpan = false,
 }: BrandIndicatorProps) {
-  const href = `https://switch-to.eu/${locale}`;
+  const href = `https://www.switch-to.eu/${locale}`;
 
   const baseClasses = cn(
     "inline-flex items-center gap-1 text-xs text-inherit opacity-60 transition-opacity hover:opacity-100",

--- a/packages/blocks/src/components/footer-copyright.tsx
+++ b/packages/blocks/src/components/footer-copyright.tsx
@@ -16,7 +16,7 @@ export function FooterCopyright() {
         year: String(currentYear),
         link: (chunks) => (
           <a
-            href="https://switch-to.eu"
+            href="https://www.switch-to.eu"
             target="_blank"
             rel="noopener noreferrer"
             className={linkClassName}

--- a/packages/trpc/src/mcp-base-url.ts
+++ b/packages/trpc/src/mcp-base-url.ts
@@ -4,6 +4,7 @@ function isAllowedHost(hostname: string): boolean {
   return (
     hostname === "localhost" ||
     hostname === "switch-to.eu" ||
+    hostname === "www.switch-to.eu" ||
     hostname.endsWith(".switch-to.eu") ||
     hostname === "switch-to.test" ||
     hostname.endsWith(".switch-to.test") ||


### PR DESCRIPTION
GSC tracks https://www.switch-to.eu with 90 days of ranking history.
Update all hardcoded non-www URLs to www to match the primary domain,
prevent canonical conflicts, and avoid unnecessary redirects.

Changes:
- Update fallback URLs in metadata/canonical/JSON-LD generators
- Update Plausible domain for main website to www
- Add www.switch-to.eu to trpc host allowlist
- Update privacy/terms links in sub-app footers and forms
- Update llm.txt "Part of" links in all tool apps
- Update brand-indicator and footer-copyright links

Subdomain URLs (scan., poll., list., etc.), brand name text in titles,
and Plausible domains for sub-apps are intentionally left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated website domain from switch-to.eu to www.switch-to.eu across all links, redirects, and metadata.
  - Enhanced sitemap to include landing pages for improved search engine visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->