### PR TITLE
fix: remove duplicate x-default hreflang entries causing Ahrefs warnings

### DIFF
--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -107,7 +107,6 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
-        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -107,6 +107,7 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
+        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -58,6 +58,7 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
+        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -58,7 +58,6 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
-        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
@@ -72,7 +72,6 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
-        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
@@ -72,6 +72,7 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
+        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -86,7 +86,6 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
-        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -86,6 +86,7 @@ export async function generateMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${path}`,
       languages: {
+        "x-default": `${siteUrl}/en${path}`,
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
       },

--- a/apps/website/app/sitemap.xml/route.ts
+++ b/apps/website/app/sitemap.xml/route.ts
@@ -17,12 +17,9 @@ interface SitemapEntry {
 }
 
 function localeAlternates(path: string): Record<string, string> {
-  return {
-    "x-default": `${baseUrl}/en${path}`,
-    ...Object.fromEntries(
-      locales.map((l) => [l, `${baseUrl}/${l}${path}`])
-    ),
-  };
+  return Object.fromEntries(
+    locales.map((l) => [l, `${baseUrl}/${l}${path}`])
+  );
 }
 
 function toXml(entries: SitemapEntry[]): string {

--- a/apps/website/app/sitemap.xml/route.ts
+++ b/apps/website/app/sitemap.xml/route.ts
@@ -17,9 +17,12 @@ interface SitemapEntry {
 }
 
 function localeAlternates(path: string): Record<string, string> {
-  return Object.fromEntries(
-    locales.map((l) => [l, `${baseUrl}/${l}${path}`])
-  );
+  return {
+    "x-default": `${baseUrl}/en${path}`,
+    ...Object.fromEntries(
+      locales.map((l) => [l, `${baseUrl}/${l}${path}`])
+    ),
+  };
 }
 
 function toXml(entries: SitemapEntry[]): string {

--- a/apps/website/lib/service-metadata.ts
+++ b/apps/website/lib/service-metadata.ts
@@ -136,7 +136,6 @@ export async function generateServiceMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${basePath}`,
       languages: {
-        "x-default": `${siteUrl}/en${basePath}`,
         en: `${siteUrl}/en${basePath}`,
         nl: `${siteUrl}/nl${basePath}`,
       },

--- a/apps/website/lib/service-metadata.ts
+++ b/apps/website/lib/service-metadata.ts
@@ -136,6 +136,7 @@ export async function generateServiceMetadata({
     alternates: {
       canonical: `${siteUrl}/${locale}${basePath}`,
       languages: {
+        "x-default": `${siteUrl}/en${basePath}`,
         en: `${siteUrl}/en${basePath}`,
         nl: `${siteUrl}/nl${basePath}`,
       },

--- a/packages/i18n/src/proxy.ts
+++ b/packages/i18n/src/proxy.ts
@@ -9,6 +9,7 @@ export function createI18nMiddleware(options?: I18nMiddlewareOptions) {
   return createMiddleware({
     ...routing,
     localeDetection: options?.localeDetection ?? false,
+    alternateLinks: false,
   });
 }
 

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -12,15 +12,8 @@ export function generateLanguageAlternates(path: string, locale: Locale) {
 
   return {
     canonical: `${siteUrl}/${locale}/${path}`,
-    languages: routing.locales.reduce(
-      (acc, l) => ({
-        ...acc,
-        [l]: `${siteUrl}/${l}/${path}`,
-      }),
-      { "x-default": `${siteUrl}/${routing.defaultLocale}/${path}` } as Record<
-        string,
-        string
-      >,
+    languages: Object.fromEntries(
+      routing.locales.map((l) => [l, `${siteUrl}/${l}/${path}`]),
     ),
   };
 }

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -12,8 +12,15 @@ export function generateLanguageAlternates(path: string, locale: Locale) {
 
   return {
     canonical: `${siteUrl}/${locale}/${path}`,
-    languages: Object.fromEntries(
-      routing.locales.map((l) => [l, `${siteUrl}/${l}/${path}`]),
+    languages: routing.locales.reduce(
+      (acc, l) => ({
+        ...acc,
+        [l]: `${siteUrl}/${l}/${path}`,
+      }),
+      { "x-default": `${siteUrl}/${routing.defaultLocale}/${path}` } as Record<
+        string,
+        string
+      >,
     ),
   };
 }


### PR DESCRIPTION
Every page included both x-default and en hreflang tags pointing to the
same URL, which Ahrefs flagged as "More than one page for same language
in hreflang" on 108 pages. Removed x-default from all 7 locations
(shared utility, sitemap, and 5 page-level metadata). Since all locales
use explicit prefixes (/en/, /nl/), x-default is redundant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified language alternate link configuration across all guide and service pages by removing default language fallback entries from page metadata.
  * Updated language routing middleware configuration to explicitly manage locale alternates and disable automatic alternate link generation.
  * Refined language alternate link generation utilities to support only explicit locale alternates instead of including default entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->