### PR TITLE
fix(llms.txt): satisfy validator — tighten summary, cut low-signal links

### DIFF
--- a/apps/website/app/api/llm/[locale]/guides/[slug]/route.ts
+++ b/apps/website/app/api/llm/[locale]/guides/[slug]/route.ts
@@ -1,12 +1,17 @@
 import { unstable_cache } from "next/cache";
+import { locales, type Locale } from "@switch-to-eu/i18n/routing";
 import { getPayload } from "@/lib/payload";
 import { guideToMarkdown } from "@/lib/llm-content";
 
 export async function GET(
   _request: Request,
-  { params }: { params: Promise<{ slug: string }> }
+  { params }: { params: Promise<{ locale: string; slug: string }> }
 ) {
-  const { slug } = await params;
+  const { locale, slug } = await params;
+
+  if (!locales.includes(locale as Locale)) {
+    return new Response("Not found", { status: 404 });
+  }
 
   const getGuide = unstable_cache(
     async () => {
@@ -17,7 +22,7 @@ export async function GET(
           slug: { equals: slug },
           _status: { equals: "published" },
         },
-        locale: "en",
+        locale: locale as Locale,
         depth: 2,
         limit: 1,
       });
@@ -25,7 +30,7 @@ export async function GET(
       if (!doc) return null;
       return guideToMarkdown(doc);
     },
-    [`llm-guide-${slug}`],
+    [`llm-guide-${locale}-${slug}`],
     { tags: ["guides"] }
   );
 

--- a/apps/website/app/api/llm/[locale]/services/[slug]/route.ts
+++ b/apps/website/app/api/llm/[locale]/services/[slug]/route.ts
@@ -1,12 +1,17 @@
 import { unstable_cache } from "next/cache";
+import { locales, type Locale } from "@switch-to-eu/i18n/routing";
 import { getPayload } from "@/lib/payload";
 import { serviceToMarkdown } from "@/lib/llm-content";
 
 export async function GET(
   _request: Request,
-  { params }: { params: Promise<{ slug: string }> }
+  { params }: { params: Promise<{ locale: string; slug: string }> }
 ) {
-  const { slug } = await params;
+  const { locale, slug } = await params;
+
+  if (!locales.includes(locale as Locale)) {
+    return new Response("Not found", { status: 404 });
+  }
 
   const getService = unstable_cache(
     async () => {
@@ -17,7 +22,7 @@ export async function GET(
           slug: { equals: slug },
           _status: { equals: "published" },
         },
-        locale: "en",
+        locale: locale as Locale,
         depth: 1,
         limit: 1,
       });
@@ -25,7 +30,7 @@ export async function GET(
       if (!doc) return null;
       return serviceToMarkdown(doc);
     },
-    [`llm-service-${slug}`],
+    [`llm-service-${locale}-${slug}`],
     { tags: ["services"] }
   );
 

--- a/apps/website/app/robots.ts
+++ b/apps/website/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      allow: ["/", "/api/llm/"],
+      allow: ["/", "/api/llm/", "/api/media/"],
       disallow: "/api/",
     },
     sitemap: `${baseUrl}/sitemap.xml`,

--- a/apps/website/components/SearchInput.tsx
+++ b/apps/website/components/SearchInput.tsx
@@ -153,8 +153,9 @@ export function SearchInput({
         size={size === "lg" ? "lg" : "sm"}
         className={className}
         onClick={() => setOpen(true)}
+        aria-label={t("searchDialogTitle")}
       >
-        <Search className={`${size === "lg" ? "h-5 w-5" : "h-4 w-4"} mr-2`} />
+        <Search className={size === "lg" ? "h-5 w-5" : "h-4 w-4"} />
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>

--- a/apps/website/lib/llm-content.ts
+++ b/apps/website/lib/llm-content.ts
@@ -209,7 +209,6 @@ export function buildLlmsIndex(
   const lines: string[] = [];
 
   lines.push("# switch-to.eu");
-  lines.push("");
   lines.push(
     "> European alternatives to Big Tech services. Honest reviews, privacy research, GDPR compliance checks, and step-by-step migration guides."
   );
@@ -219,22 +218,19 @@ export function buildLlmsIndex(
   );
   lines.push("");
 
-  // Key pages
-  lines.push("## Pages");
+  // Core pages
+  lines.push("## Core pages");
   lines.push("");
-  lines.push(`- [Home](${BASE_URL}/en)`);
-  lines.push(`- [About](${BASE_URL}/en/about)`);
+  lines.push(`- [Home](${BASE_URL}/en): Browse EU alternatives and migration guides`);
+  lines.push(`- [About](${BASE_URL}/en/about): Mission and story behind switch-to.eu`);
   lines.push(`- [Tools](${BASE_URL}/en/tools): Free privacy-focused tools built in the EU`);
-  lines.push(`- [Contribute](${BASE_URL}/en/contribute): Help improve switch-to.eu`);
   lines.push(`- [Search](${BASE_URL}/en/search): Search all services and guides`);
-  lines.push(`- [Feedback](${BASE_URL}/en/feedback)`);
-  lines.push(`- [Privacy policy](${BASE_URL}/en/privacy)`);
-  lines.push(`- [Terms](${BASE_URL}/en/terms)`);
+  lines.push(`- [Contribute](${BASE_URL}/en/contribute): Help improve switch-to.eu`);
   lines.push("");
 
-  // Categories
+  // Categories (top-level landing pages for each service category)
   if (categories.length > 0) {
-    lines.push("## Categories");
+    lines.push("## Service categories");
     lines.push("");
     for (const c of categories) {
       lines.push(`- [${c.title}](${BASE_URL}/en/services/${c.slug}): ${c.description}`);
@@ -242,14 +238,13 @@ export function buildLlmsIndex(
     lines.push("");
   }
 
-  // EU & EU-friendly services grouped by category
+  // EU & EU-friendly services (one link each, no sub-links)
   const eu = services.filter(
     (s) => s.region === "eu" || s.region === "eu-friendly"
   );
-  const nonEu = services.filter((s) => s.region === "non-eu");
 
   if (eu.length > 0) {
-    lines.push("## EU & EU-Friendly Services");
+    lines.push("## EU services");
     lines.push("");
     const grouped = groupByCategory(eu);
     for (const [categoryName, items] of grouped) {
@@ -265,38 +260,14 @@ export function buildLlmsIndex(
         lines.push(
           `- [${s.name}](${BASE_URL}/en/services/eu/${s.slug}): ${s.description}${suffix}`
         );
-        if (s.startingPrice) {
-          lines.push(`  - [Pricing](${BASE_URL}/en/services/eu/${s.slug}/pricing)`);
-        }
-        if (s.gdprCompliance || (s.certifications && s.certifications.length > 0)) {
-          lines.push(`  - [Security & privacy](${BASE_URL}/en/services/eu/${s.slug}/security)`);
-        }
-        lines.push(`  - [Full details (markdown)](${BASE_URL}/services/${s.slug}.md)`);
       }
       lines.push("");
     }
   }
 
-  if (nonEu.length > 0) {
-    lines.push("## Non-EU Services");
-    lines.push("");
-    const grouped = groupByCategory(nonEu);
-    for (const [categoryName, items] of grouped) {
-      lines.push(`### ${categoryName}`);
-      lines.push("");
-      for (const s of items) {
-        lines.push(
-          `- [${s.name}](${BASE_URL}/en/services/non-eu/${s.slug}): ${s.description}`
-        );
-        lines.push(`  - [Full details (markdown)](${BASE_URL}/services/${s.slug}.md)`);
-      }
-      lines.push("");
-    }
-  }
-
-  // Migration guides grouped by category
+  // Migration guides (one link each, no sub-links)
   if (guides.length > 0) {
-    lines.push("## Migration Guides");
+    lines.push("## Migration guides");
     lines.push("");
     const grouped = groupGuidesByCategory(guides);
     for (const [categoryName, items] of grouped) {
@@ -314,18 +285,6 @@ export function buildLlmsIndex(
         lines.push(
           `- [${label}](${BASE_URL}/en/guides/${catSlug}/${g.slug}): ${g.description} (${meta})`
         );
-        lines.push(`  - [Full details (markdown)](${BASE_URL}/guides/${g.slug}.md)`);
-
-        // Comparison page link
-        if (
-          typeof g.targetService === "object" &&
-          typeof g.sourceService === "object" &&
-          g.targetService.region !== "non-eu"
-        ) {
-          lines.push(
-            `  - [Comparison: ${g.targetService.name} vs ${g.sourceService.name}](${BASE_URL}/en/services/eu/${g.targetService.slug}/vs-${g.sourceService.slug})`
-          );
-        }
       }
       lines.push("");
     }

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -83,9 +83,17 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return {
       beforeFiles: [
-        // LLM-friendly .md URLs → API route handlers
-        { source: "/services/:slug.md", destination: "/api/llm/services/:slug" },
-        { source: "/guides/:slug.md", destination: "/api/llm/guides/:slug" },
+        // LLM-friendly .md URLs → API route handlers.
+        // Locale-prefixed so the /services/:path* → /en/services/:path* locale
+        // redirect doesn't clobber these before the rewrite fires.
+        {
+          source: "/:locale(en|nl)/services/:slug.md",
+          destination: "/api/llm/:locale/services/:slug",
+        },
+        {
+          source: "/:locale(en|nl)/guides/:slug.md",
+          destination: "/api/llm/:locale/guides/:slug",
+        },
       ],
     };
   },


### PR DESCRIPTION
- Place blockquote summary directly after H1 (no blank line) so strict
  parsers recognize it as the summary.
- Drop non-EU services section and all per-item sub-links (pricing,
  security, full-details .md, comparison pages). The .md links were
  systematically broken because the /services/:path* locale redirect
  fires before the /services/:slug.md rewrite, so every .md URL 308'd
  into a non-existent /en/services/:slug.md.
- Reduces link count from 161 to well under the sitemap threshold and
  focuses llms.txt on high-signal docs: core pages, category landings,
  one link per EU service, one link per guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-language support for guides and services across available locales.

* **Improvements**
  * Enhanced search input accessibility with improved labels.
  * Streamlined service and guide listings with focus on EU services and simplified presentation.
  * Extended search engine crawling permissions for additional resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->