### PR TITLE
fix(llm): drop _status=published filter from service/guide detail routes

### DIFF
--- a/apps/website/app/api/llm/[locale]/guides/[slug]/route.ts
+++ b/apps/website/app/api/llm/[locale]/guides/[slug]/route.ts
@@ -20,7 +20,6 @@ export async function GET(
         collection: "guides",
         where: {
           slug: { equals: slug },
-          _status: { equals: "published" },
         },
         locale: locale as Locale,
         depth: 2,

--- a/apps/website/app/api/llm/[locale]/services/[slug]/route.ts
+++ b/apps/website/app/api/llm/[locale]/services/[slug]/route.ts
@@ -20,7 +20,6 @@ export async function GET(
         collection: "services",
         where: {
           slug: { equals: slug },
-          _status: { equals: "published" },
         },
         locale: locale as Locale,
         depth: 1,


### PR DESCRIPTION
The llms.txt index lists docs without a status filter, but the detail
routes required _status=published. That mismatch produced "not found"
responses when the index linked to docs whose latest version is a draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guides and services are now accessible via API regardless of their publication status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->