### PR TITLE
fix(seo): self-canonical homepage URLs, add x-default, noindex 404s

### DIFF
--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -109,6 +109,7 @@ export async function generateMetadata({
       languages: {
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
+        "x-default": `${siteUrl}/en${path}`,
       },
     },
     openGraph: {

--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -11,6 +11,8 @@ import { getTranslations } from "next-intl/server";
 import { GuideProgressWithI18n as GuideProgress } from "@/components/guides/guide-progress";
 import { GuideStep } from "@/components/guides/GuideStep";
 import { Locale } from "next-intl";
+import type { Locale as AppLocale } from "@switch-to-eu/i18n/routing";
+import { generateLanguageAlternates } from "@switch-to-eu/i18n/utils";
 import { notFound } from "next/navigation";
 import { Container } from "@switch-to-eu/blocks/components/container";
 import { PageLayout } from "@switch-to-eu/blocks/components/page-layout";
@@ -88,8 +90,6 @@ export async function generateMetadata({
       ? guide.targetService.name
       : String(guide.targetService ?? "");
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
-  const path = `/guides/${category}/${service}`;
   const title = guide.metaTitle || t("title", { title: guide.title });
   const description = guide.metaDescription || guide.description;
 
@@ -104,14 +104,7 @@ export async function generateMetadata({
       category,
     ],
     authors: guide.author ? [{ name: guide.author }] : undefined,
-    alternates: {
-      canonical: `${siteUrl}/${locale}${path}`,
-      languages: {
-        en: `${siteUrl}/en${path}`,
-        nl: `${siteUrl}/nl${path}`,
-        "x-default": `${siteUrl}/en${path}`,
-      },
-    },
+    alternates: generateLanguageAlternates(`guides/${category}/${service}`, locale as AppLocale),
     openGraph: {
       title,
       description,

--- a/apps/website/app/(frontend)/[locale]/not-found.tsx
+++ b/apps/website/app/(frontend)/[locale]/not-found.tsx
@@ -1,22 +1,27 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
 
-export const metadata: Metadata = {
-  title: "Page not found | switch-to.eu",
-  robots: { index: false, follow: false },
-  alternates: { canonical: null },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("notFound");
+  return {
+    title: t("title"),
+    robots: { index: false, follow: false },
+    alternates: { canonical: null },
+  };
+}
 
-export default function LocaleNotFound() {
+export default async function LocaleNotFound() {
+  const t = await getTranslations("notFound");
   return (
     <div className="flex flex-1 flex-col items-center justify-center py-20">
-      <h1 className="text-4xl font-bold mb-4">404</h1>
-      <p className="text-muted-foreground mb-6">Page not found</p>
+      <h1 className="text-4xl font-bold mb-4">{t("heading")}</h1>
+      <p className="text-muted-foreground mb-6">{t("message")}</p>
       <Link
         href="/"
         className="text-primary underline hover:no-underline"
       >
-        Go home
+        {t("cta")}
       </Link>
     </div>
   );

--- a/apps/website/app/(frontend)/[locale]/not-found.tsx
+++ b/apps/website/app/(frontend)/[locale]/not-found.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { Link } from "@switch-to-eu/i18n/navigation";
 
 export const metadata: Metadata = {
   title: "Page not found | switch-to.eu",
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   alternates: { canonical: null },
 };
 
-export default function NotFound() {
+export default function LocaleNotFound() {
   return (
     <div className="flex flex-1 flex-col items-center justify-center py-20">
       <h1 className="text-4xl font-bold mb-4">404</h1>

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -60,6 +60,7 @@ export async function generateMetadata({
       languages: {
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
+        "x-default": `${siteUrl}/en${path}`,
       },
     },
     openGraph: {

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -9,6 +9,8 @@ import { Container } from "@switch-to-eu/blocks/components/container";
 import { PageLayout } from "@switch-to-eu/blocks/components/page-layout";
 import { getTranslations } from "next-intl/server";
 import { Locale } from "next-intl";
+import type { Locale as AppLocale } from "@switch-to-eu/i18n/routing";
+import { generateLanguageAlternates } from "@switch-to-eu/i18n/utils";
 import { NewsletterCta } from "@/components/NewsletterCta";
 import { Banner } from "@switch-to-eu/blocks/components/banner";
 import { SectionHeading } from "@switch-to-eu/blocks/components/section-heading";
@@ -40,8 +42,6 @@ export async function generateMetadata({
     categoryData?.description ||
     `EU-based alternatives for common ${category} services that prioritize privacy and data protection.`;
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
-  const path = `/services/${category}`;
   const title = categoryData?.metaTitle || `${pageTitle} | switch-to.eu`;
   const description = categoryData?.metaDescription || pageDescription;
 
@@ -55,14 +55,7 @@ export async function generateMetadata({
       "GDPR compliant",
       category,
     ],
-    alternates: {
-      canonical: `${siteUrl}/${locale}${path}`,
-      languages: {
-        en: `${siteUrl}/en${path}`,
-        nl: `${siteUrl}/nl${path}`,
-        "x-default": `${siteUrl}/en${path}`,
-      },
-    },
+    alternates: generateLanguageAlternates(`services/${category}`, locale as AppLocale),
     openGraph: {
       title,
       description,

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
@@ -74,6 +74,7 @@ export async function generateMetadata({
       languages: {
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
+        "x-default": `${siteUrl}/en${path}`,
       },
     },
     openGraph: {

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
@@ -7,6 +7,8 @@ import { PageLayout } from "@switch-to-eu/blocks/components/page-layout";
 
 import { getTranslations } from "next-intl/server";
 import type { Locale } from "next-intl";
+import type { Locale as AppLocale } from "@switch-to-eu/i18n/routing";
+import { generateLanguageAlternates } from "@switch-to-eu/i18n/utils";
 import type { Service, Guide } from "@/payload-types";
 import { getServiceBySlug } from "@/lib/services";
 
@@ -61,22 +63,13 @@ export async function generateMetadata({
 
   if (!euService || !nonEuService) return { title: "Not Found" };
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
-  const path = `/services/eu/${service_name}/vs-${slug}`;
   const title = `${euService.name} vs ${nonEuService.name} | switch-to.eu`;
   const description = `Compare ${euService.name} and ${nonEuService.name}. See how the EU alternative stacks up on privacy, pricing, and features.`;
 
   return {
     title,
     description,
-    alternates: {
-      canonical: `${siteUrl}/${locale}${path}`,
-      languages: {
-        en: `${siteUrl}/en${path}`,
-        nl: `${siteUrl}/nl${path}`,
-        "x-default": `${siteUrl}/en${path}`,
-      },
-    },
+    alternates: generateLanguageAlternates(`services/eu/${service_name}/vs-${slug}`, locale as AppLocale),
     openGraph: {
       title,
       description,

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -88,6 +88,7 @@ export async function generateMetadata({
       languages: {
         en: `${siteUrl}/en${path}`,
         nl: `${siteUrl}/nl${path}`,
+        "x-default": `${siteUrl}/en${path}`,
       },
     },
     openGraph: {

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -10,6 +10,8 @@ import { ServiceCard } from "@/components/ui/ServiceCard";
 import { getTranslations } from "next-intl/server";
 import { Metadata } from "next";
 import { Locale } from "next-intl";
+import type { Locale as AppLocale } from "@switch-to-eu/i18n/routing";
+import { generateLanguageAlternates } from "@switch-to-eu/i18n/utils";
 import { RegionBadge } from "@switch-to-eu/ui/components/region-badge";
 import { WarningCollapsible } from "@/components/guides/WarningCollapsible";
 import { Container } from "@switch-to-eu/blocks/components/container";
@@ -67,8 +69,6 @@ export async function generateMetadata({
 
   const tags = (service.tags ?? []).map((t) => t.tag);
 
-  const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
-  const path = `/services/non-eu/${service_name}`;
   const title = service.metaTitle || `${service.name} | switch-to.eu`;
   const description = service.metaDescription || service.description;
 
@@ -83,14 +83,7 @@ export async function generateMetadata({
       "EU alternatives",
       ...tags,
     ],
-    alternates: {
-      canonical: `${siteUrl}/${locale}${path}`,
-      languages: {
-        en: `${siteUrl}/en${path}`,
-        nl: `${siteUrl}/nl${path}`,
-        "x-default": `${siteUrl}/en${path}`,
-      },
-    },
+    alternates: generateLanguageAlternates(`services/non-eu/${service_name}`, locale as AppLocale),
     openGraph: {
       title,
       description,

--- a/apps/website/app/sitemap.xml/route.ts
+++ b/apps/website/app/sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 import { getPayload } from "@/lib/payload";
 import type { Service, Guide, Category } from "@/payload-types";
-import { routing } from "@switch-to-eu/i18n/routing";
+import { routing, defaultLocale } from "@switch-to-eu/i18n/routing";
 import { unstable_noStore as noStore } from "next/cache";
 
 const baseUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
@@ -17,9 +17,12 @@ interface SitemapEntry {
 }
 
 function localeAlternates(path: string): Record<string, string> {
-  return Object.fromEntries(
-    locales.map((l) => [l, `${baseUrl}/${l}${path}`])
-  );
+  return {
+    ...Object.fromEntries(
+      locales.map((l) => [l, `${baseUrl}/${l}${path}`])
+    ),
+    "x-default": `${baseUrl}/${defaultLocale}${path}`,
+  };
 }
 
 function toXml(entries: SitemapEntry[]): string {

--- a/apps/website/lib/service-metadata.ts
+++ b/apps/website/lib/service-metadata.ts
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { generateLanguageAlternates } from "@switch-to-eu/i18n/utils";
+import type { Locale } from "@switch-to-eu/i18n/routing";
 import { getServiceBySlug, getCategorySlug } from "@/lib/services";
 
 const siteUrl = process.env.NEXT_PUBLIC_URL || "https://www.switch-to.eu";
@@ -133,14 +135,7 @@ export async function generateServiceMetadata({
     title,
     description,
     ...(keywords ? { keywords } : {}),
-    alternates: {
-      canonical: `${siteUrl}/${locale}${basePath}`,
-      languages: {
-        en: `${siteUrl}/en${basePath}`,
-        nl: `${siteUrl}/nl${basePath}`,
-        "x-default": `${siteUrl}/en${basePath}`,
-      },
-    },
+    alternates: generateLanguageAlternates(basePath.slice(1), locale as Locale),
     openGraph: {
       title,
       description,

--- a/apps/website/lib/service-metadata.ts
+++ b/apps/website/lib/service-metadata.ts
@@ -138,6 +138,7 @@ export async function generateServiceMetadata({
       languages: {
         en: `${siteUrl}/en${basePath}`,
         nl: `${siteUrl}/nl${basePath}`,
+        "x-default": `${siteUrl}/en${basePath}`,
       },
     },
     openGraph: {

--- a/packages/i18n/messages/website/en.json
+++ b/packages/i18n/messages/website/en.json
@@ -704,5 +704,11 @@
     "emailLabel": "Email address",
     "submitLabel": "Subscribe",
     "successMessage": "Thank you for subscribing! You will receive our next update in your inbox."
+  },
+  "notFound": {
+    "title": "Page not found | switch-to.eu",
+    "heading": "404",
+    "message": "Page not found",
+    "cta": "Go home"
   }
 }

--- a/packages/i18n/messages/website/nl.json
+++ b/packages/i18n/messages/website/nl.json
@@ -698,5 +698,11 @@
     "emailLabel": "E-mailadres",
     "submitLabel": "Schrijf je in",
     "successMessage": "Bedankt voor je aanmelding! Je ontvangt onze volgende update in je inbox."
+  },
+  "notFound": {
+    "title": "Pagina niet gevonden | switch-to.eu",
+    "heading": "404",
+    "message": "Pagina niet gevonden",
+    "cta": "Naar de startpagina"
   }
 }

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -1,19 +1,22 @@
-import { routing, type Locale } from "./routing";
+import { routing, defaultLocale, type Locale } from "./routing";
 
 /**
  * Generate language alternates for metadata
  * @param path - The path after the locale, should start without a slash (e.g., "contribute" not "/contribute")
  * @param locale - The current locale
- * @param baseUrl - The base URL of the site (default: process.env.NEXT_PUBLIC_URL)
  * @returns Object with canonical URL and languages object for alternates metadata
  */
 export function generateLanguageAlternates(path: string, locale: Locale) {
   const siteUrl = process.env.NEXT_PUBLIC_URL || "";
+  const suffix = path ? `/${path}` : "";
 
   return {
-    canonical: `${siteUrl}/${locale}/${path}`,
-    languages: Object.fromEntries(
-      routing.locales.map((l) => [l, `${siteUrl}/${l}/${path}`]),
-    ),
+    canonical: `${siteUrl}/${locale}${suffix}`,
+    languages: {
+      ...Object.fromEntries(
+        routing.locales.map((l) => [l, `${siteUrl}/${l}${suffix}`]),
+      ),
+      "x-default": `${siteUrl}/${defaultLocale}${suffix}`,
+    },
   };
 }


### PR DESCRIPTION
Three bugs were causing GSC to flag pages as "Alternative page with
proper canonical tag":

1. Homepage canonical included a trailing slash (/nl/) while the served
   URL does not (/nl), creating a canonical <-> 308 loop. Dropped the
   trailing slash when the path is empty.

2. 404 pages inherited the locale layout's canonical (/nl/), making
   not-found responses look like alternatives of the homepage. Added
   dedicated metadata with robots: noindex and no canonical.

3. x-default hreflang was missing everywhere. Added it alongside en/nl
   in utils, service-metadata, inline generators, and the sitemap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced localized 404 error pages that provide helpful guidance when users navigate to content that does not exist, improving the overall user experience during navigation errors.
  * Enhanced language alternate metadata configuration across service pages and guides to improve search engine indexing and content visibility across all supported languages.
  * Updated site navigation records with optimized default language handling for better content discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->