### PR TITLE
feat(category): use affiliate URL and actionable copy on featured card

### DIFF
--- a/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
@@ -76,25 +76,10 @@ export default async function LandingPage({
       ? page.category.slug
       : null;
 
-  // Map resolved services to ServiceFrontmatter shape for RecommendedAlternative
   const recommendedServices = Array.isArray(page.recommendedServices)
-    ? page.recommendedServices
-        .filter((s): s is Service => typeof s === "object" && s !== null)
-        .map((service) => ({
-          name: service.name,
-          category: typeof service.category === "object" && service.category !== null ? service.category.slug : "",
-          location: service.location,
-          region: service.region as "eu" | "non-eu" | "eu-friendly" | undefined,
-          freeOption: service.freeOption ?? false,
-          startingPrice: service.startingPrice ?? undefined,
-          description: service.description,
-          url: service.url,
-          affiliateUrl: service.affiliateUrl,
-          screenshot: typeof service.screenshot === "object" && service.screenshot !== null ? service.screenshot.url ?? undefined : undefined,
-          features: service.features?.map((f) => f.feature) ?? undefined,
-          tags: service.tags?.map((t) => t.tag) ?? undefined,
-          featured: service.featured ?? undefined,
-        }))
+    ? page.recommendedServices.filter(
+        (s): s is Service => typeof s === "object" && s !== null
+      )
     : [];
 
   // Resolve the related non-EU service

--- a/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
@@ -89,6 +89,7 @@ export default async function LandingPage({
           startingPrice: service.startingPrice ?? undefined,
           description: service.description,
           url: service.url,
+          affiliateUrl: service.affiliateUrl,
           screenshot: typeof service.screenshot === "object" && service.screenshot !== null ? service.screenshot.url ?? undefined : undefined,
           features: service.features?.map((f) => f.feature) ?? undefined,
           tags: service.tags?.map((t) => t.tag) ?? undefined,

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -119,8 +119,6 @@ export default async function ServicesCategoryPage({
 
   const featuredServices = euServices.filter((s) => s.featured === true);
   const regularServices = euServices.filter((s) => !s.featured);
-  const allDisplayServices =
-    regularServices.length > 0 ? regularServices : euServices;
 
   const pageTitle =
     categoryData?.title || `${capitalizedCategory} Service Alternatives`;
@@ -184,7 +182,7 @@ export default async function ServicesCategoryPage({
           </SectionHeading>
 
           <div className="grid gap-0 md:gap-5 auto-rows-fr grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {allDisplayServices.map((service, index) => (
+            {regularServices.map((service, index) => (
               <ServiceCard
                 key={service.name}
                 service={service}
@@ -192,7 +190,7 @@ export default async function ServicesCategoryPage({
                 colorIndex={index}
               />
             ))}
-            <SuggestServiceCard colorIndex={allDisplayServices.length} />
+            <SuggestServiceCard colorIndex={regularServices.length} />
           </div>
         </Container>
 

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -109,6 +109,7 @@ export default async function ServicesCategoryPage({
       region: { in: ["eu", "eu-friendly"] },
     },
     locale: locale as 'en' | 'nl',
+    depth: 1,
     limit: 100,
   }) as { docs: Service[] };
 
@@ -116,31 +117,10 @@ export default async function ServicesCategoryPage({
     notFound();
   }
 
-  // Map Payload services to match ServiceFrontmatter shape for existing components
-  const mappedServices = euServices.map((service) => ({
-    ...service,
-    category: category,
-    freeOption: service.freeOption ?? false,
-    featured: service.featured ?? false,
-    screenshot:
-      typeof service.screenshot === "object" && service.screenshot
-        ? service.screenshot.url ?? undefined
-        : undefined,
-    features: Array.isArray(service.features)
-      ? service.features.map((f) => f.feature)
-      : [],
-    tags: Array.isArray(service.tags)
-      ? service.tags.map((t) => t.tag)
-      : [],
-  }));
-
-  const featuredServices = mappedServices.filter(
-    (service) => service.featured === true
-  );
-
-  const regularServices = mappedServices.filter((service) => !service.featured);
+  const featuredServices = euServices.filter((s) => s.featured === true);
+  const regularServices = euServices.filter((s) => !s.featured);
   const allDisplayServices =
-    regularServices.length > 0 ? regularServices : mappedServices;
+    regularServices.length > 0 ? regularServices : euServices;
 
   const pageTitle =
     categoryData?.title || `${capitalizedCategory} Service Alternatives`;

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/layout.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/layout.tsx
@@ -19,7 +19,6 @@ import {
   getCategoryId,
   getScreenshotUrl,
   getOutboundUrl,
-  toServiceCard,
 } from "@/lib/services";
 
 function getAvailableTabs(
@@ -111,10 +110,10 @@ export default async function ServiceLayout({
 
   // Fetch similar services
   const categoryId = getCategoryId(service.category);
-  const similarDocs = await getSimilarServices(categoryId, service.id, locale);
-
-  const similarServices = similarDocs.map((s) =>
-    toServiceCard(s, categorySlug)
+  const similarServices = await getSimilarServices(
+    categoryId,
+    service.id,
+    locale
   );
 
   const basePath = `/services/eu/${service_name}`;

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -144,7 +144,8 @@ export default async function ServiceDetailPage({
         freeOption: resolvedAlternative.freeOption,
         startingPrice: resolvedAlternative.startingPrice,
         description: resolvedAlternative.description,
-        url: resolvedAlternative.affiliateUrl || resolvedAlternative.url,
+        url: resolvedAlternative.url,
+        affiliateUrl: resolvedAlternative.affiliateUrl,
         screenshot:
           typeof resolvedAlternative.screenshot === "object" && resolvedAlternative.screenshot
             ? (resolvedAlternative.screenshot as { url?: string | null })

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -135,27 +135,10 @@ export default async function ServiceDetailPage({
     service.recommendedAlternative !== null
       ? (service.recommendedAlternative as Service)
       : null;
-  const recommendedAlternativeData = resolvedAlternative
-    ? {
-        name: resolvedAlternative.name,
-        slug: resolvedAlternative.slug,
-        region: resolvedAlternative.region,
-        location: resolvedAlternative.location,
-        freeOption: resolvedAlternative.freeOption,
-        startingPrice: resolvedAlternative.startingPrice,
-        description: resolvedAlternative.description,
-        url: resolvedAlternative.url,
-        affiliateUrl: resolvedAlternative.affiliateUrl,
-        screenshot:
-          typeof resolvedAlternative.screenshot === "object" && resolvedAlternative.screenshot
-            ? (resolvedAlternative.screenshot as { url?: string | null })
-            : null,
-      }
-    : null;
 
   // Find migration guides between this service and its recommended alternative
   let migrationGuides: Array<{ category: string; slug: string }> = [];
-  if (recommendedAlternativeData) {
+  if (resolvedAlternative) {
     const { docs: guideDocs } = await payload.find({
       collection: "guides",
       where: {
@@ -196,18 +179,7 @@ export default async function ServiceDetailPage({
   });
   const categoryDoc = categoryDocs[0] as Category | undefined;
 
-  let euAlternatives: Array<{
-    name: string;
-    slug: string;
-    category: string | { slug: string; title?: string };
-    region?: "eu" | "non-eu" | "eu-friendly" | null;
-    location: string;
-    freeOption?: boolean | null;
-    startingPrice?: string | null;
-    description: string;
-    url: string;
-    screenshot?: string | { url?: string | null } | null;
-  }> = [];
+  let euAlternatives: Service[] = [];
 
   if (categoryDoc) {
     const { docs: euDocs } = await payload.find({
@@ -220,27 +192,11 @@ export default async function ServiceDetailPage({
       depth: 1,
       limit: 50,
     }) as { docs: Service[] };
-    euAlternatives = euDocs.map((s) => ({
-      name: s.name,
-      slug: s.slug,
-      category:
-        typeof s.category === "object" && s.category !== null
-          ? { slug: s.category.slug, title: s.category.title }
-          : String(s.category ?? ""),
-      region: s.region as "eu" | "non-eu" | "eu-friendly" | null,
-      location: s.location,
-      freeOption: s.freeOption,
-      startingPrice: s.startingPrice,
-      description: s.description,
-      url: s.url,
-      screenshot: s.screenshot as { url?: string | null } | null,
-    }));
+    euAlternatives = euDocs;
   }
 
-  const otherAlternatives = recommendedAlternativeData
-    ? euAlternatives.filter(
-        (alt) => alt.name !== recommendedAlternativeData.name
-      )
+  const otherAlternatives = resolvedAlternative
+    ? euAlternatives.filter((alt) => alt.id !== resolvedAlternative.id)
     : euAlternatives;
 
   return (
@@ -363,9 +319,9 @@ export default async function ServiceDetailPage({
 
       <Container noPaddingMobile>
         {/* Recommended Alternative -- below body text */}
-        {recommendedAlternativeData && (
+        {resolvedAlternative && (
           <RecommendedAlternative
-            service={recommendedAlternativeData}
+            service={resolvedAlternative}
             sourceService={service.name}
             migrationGuides={migrationGuides}
           />

--- a/apps/website/components/ui/RecommendedAlternative.tsx
+++ b/apps/website/components/ui/RecommendedAlternative.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import { DecorativeShape } from "@switch-to-eu/blocks/components/decorative-shape";
+import { AffiliateDisclosure } from "@/components/ui/AffiliateDisclosure";
 
 /**
  * Service data shape compatible with Payload CMS Service documents.
@@ -14,6 +15,7 @@ export interface RecommendedAlternativeServiceData {
   startingPrice?: string | null;
   description: string;
   url?: string | null;
+  affiliateUrl?: string | null;
   screenshot?: string | { url?: string | null } | null;
 }
 
@@ -36,6 +38,7 @@ export async function RecommendedAlternative({
 
   const serviceSlug = service.slug ?? service.name.toLowerCase().replace(/\s+/g, "-");
   const regionPath = service.region?.includes("eu") ? "eu" : "non-eu";
+  const outboundUrl = service.affiliateUrl || service.url;
 
   // Resolve screenshot URL (Payload Media object or plain string)
   const screenshotUrl =
@@ -110,13 +113,31 @@ export async function RecommendedAlternative({
 
           {/* Actions */}
           <div className="flex flex-wrap gap-3">
+            {outboundUrl && (
+              <a
+                href={outboundUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block py-2.5 px-6 bg-brand-yellow text-brand-green rounded-full font-semibold text-sm hover:opacity-90 transition-opacity no-underline"
+              >
+                {t("detail.tryService", { service: service.name })} &rarr;
+              </a>
+            )}
+
+            <Link
+              href={`/services/${regionPath}/${serviceSlug}`}
+              className="inline-block py-2.5 px-6 border-2 border-brand-yellow text-brand-yellow rounded-full font-semibold text-sm hover:bg-brand-yellow hover:text-brand-green transition-colors no-underline"
+            >
+              {t("detail.recommendedAlternative.learnMore")}
+            </Link>
+
             {sourceService &&
               migrationGuides.length > 0 &&
               migrationGuides.map((guide) => (
                 <Link
                   key={`${guide.category}-${guide.slug}`}
                   href={`/guides/${guide.category}/${guide.slug}`}
-                  className="inline-block py-2.5 px-6 bg-brand-yellow text-brand-green rounded-full font-semibold text-sm hover:opacity-90 transition-opacity no-underline"
+                  className="inline-block py-2.5 px-6 border-2 border-brand-yellow text-brand-yellow rounded-full font-semibold text-sm hover:bg-brand-yellow hover:text-brand-green transition-colors no-underline"
                 >
                   {t("detail.recommendedAlternative.migrateFrom", {
                     source: sourceService,
@@ -124,25 +145,11 @@ export async function RecommendedAlternative({
                   })}
                 </Link>
               ))}
-
-            <Link
-              href={`/services/${regionPath}/${serviceSlug}`}
-              className="inline-block py-2.5 px-6 bg-brand-yellow text-brand-green rounded-full font-semibold text-sm hover:opacity-90 transition-opacity no-underline"
-            >
-              {t("detail.recommendedAlternative.viewDetails")}
-            </Link>
-
-            {service.url && (
-              <a
-                href={service.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-block py-2.5 px-6 border-2 border-brand-yellow text-brand-yellow rounded-full font-semibold text-sm hover:bg-brand-yellow hover:text-brand-green transition-colors no-underline"
-              >
-                {t("detail.visitWebsite")} &rarr;
-              </a>
-            )}
           </div>
+
+          {outboundUrl && service.affiliateUrl && (
+            <AffiliateDisclosure className="mt-3 text-brand-cream/40 hover:text-brand-cream/60 decoration-brand-cream/30" />
+          )}
         </div>
 
         {/* Right: Screenshot */}

--- a/apps/website/components/ui/RecommendedAlternative.tsx
+++ b/apps/website/components/ui/RecommendedAlternative.tsx
@@ -2,22 +2,22 @@ import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import { DecorativeShape } from "@switch-to-eu/blocks/components/decorative-shape";
 import { AffiliateDisclosure } from "@/components/ui/AffiliateDisclosure";
+import { getOutboundUrl, getScreenshotUrl } from "@/lib/services";
+import type { Service } from "@/payload-types";
 
-/**
- * Service data shape compatible with Payload CMS Service documents.
- */
-export interface RecommendedAlternativeServiceData {
-  name: string;
-  slug?: string;
-  region?: "eu" | "non-eu" | "eu-friendly" | null;
-  location?: string | null;
-  freeOption?: boolean | null;
-  startingPrice?: string | null;
-  description: string;
-  url?: string | null;
-  affiliateUrl?: string | null;
-  screenshot?: string | { url?: string | null } | null;
-}
+export type RecommendedAlternativeService = Pick<
+  Service,
+  | "name"
+  | "slug"
+  | "region"
+  | "location"
+  | "freeOption"
+  | "startingPrice"
+  | "description"
+  | "url"
+  | "affiliateUrl"
+  | "screenshot"
+>;
 
 interface MigrationGuide {
   category: string;
@@ -29,22 +29,15 @@ export async function RecommendedAlternative({
   sourceService,
   migrationGuides = [],
 }: {
-  service: RecommendedAlternativeServiceData;
+  service: RecommendedAlternativeService;
   sourceService: string;
   migrationGuides: MigrationGuide[];
 }) {
-  if (!service) return null;
   const t = await getTranslations("services");
 
-  const serviceSlug = service.slug ?? service.name.toLowerCase().replace(/\s+/g, "-");
-  const regionPath = service.region?.includes("eu") ? "eu" : "non-eu";
-  const outboundUrl = service.affiliateUrl || service.url;
-
-  // Resolve screenshot URL (Payload Media object or plain string)
-  const screenshotUrl =
-    typeof service.screenshot === "object" && service.screenshot !== null
-      ? service.screenshot.url ?? undefined
-      : service.screenshot ?? undefined;
+  const regionPath = service.region.includes("eu") ? "eu" : "non-eu";
+  const outboundUrl = getOutboundUrl(service);
+  const screenshotUrl = getScreenshotUrl(service.screenshot);
 
   return (
     <div className="bg-brand-green md:rounded-3xl relative overflow-hidden">
@@ -125,7 +118,7 @@ export async function RecommendedAlternative({
             )}
 
             <Link
-              href={`/services/${regionPath}/${serviceSlug}`}
+              href={`/services/${regionPath}/${service.slug}`}
               className="inline-block py-2.5 px-6 border-2 border-brand-yellow text-brand-yellow rounded-full font-semibold text-sm hover:bg-brand-yellow hover:text-brand-green transition-colors no-underline"
             >
               {t("detail.recommendedAlternative.learnMore")}

--- a/apps/website/components/ui/ServiceCard.tsx
+++ b/apps/website/components/ui/ServiceCard.tsx
@@ -4,25 +4,21 @@ import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import { getCardColor } from "@switch-to-eu/ui/lib/brand-palette";
 import { shapes } from "@switch-to-eu/blocks/shapes";
+import { getCategorySlug, getScreenshotUrl } from "@/lib/services";
+import type { Service } from "@/payload-types";
 
-/**
- * Service data shape compatible with Payload CMS Service documents.
- * Accepts both resolved relationship objects and raw values.
- */
-export interface ServiceCardData {
-  name: string;
-  slug?: string;
-  category: string | { slug: string; title?: string };
-  region?: "eu" | "non-eu" | "eu-friendly" | null;
-  location: string;
-  freeOption?: boolean | null;
-  startingPrice?: string | null;
-  description: string;
-  url: string;
-  screenshot?: string | { url?: string | null } | null;
-  features?: Array<{ feature: string }> | string[] | null;
-  tags?: Array<{ tag: string }> | string[] | null;
-}
+export type ServiceCardService = Pick<
+  Service,
+  | "name"
+  | "slug"
+  | "category"
+  | "region"
+  | "location"
+  | "freeOption"
+  | "startingPrice"
+  | "description"
+  | "screenshot"
+>;
 
 const SERVICE_SHAPES = [
   "spark",
@@ -44,28 +40,19 @@ export async function ServiceCard({
   showCategory = true,
   colorIndex = 0,
 }: {
-  service: ServiceCardData;
+  service: ServiceCardService;
   showCategory?: boolean;
   colorIndex?: number;
 }) {
   const t = await getTranslations("services");
 
-  const categorySlug =
-    typeof service.category === "object"
-      ? service.category.slug
-      : service.category;
+  const categorySlug = getCategorySlug(service.category);
   const categoryFormatted =
     categorySlug.charAt(0).toUpperCase() + categorySlug.slice(1);
 
-  const serviceSlug = service.slug ?? service.name.toLowerCase().replace(/\s+/g, "-");
   const regionPath = service.region === "non-eu" ? "non-eu" : "eu";
-  const serviceLink = `/services/${regionPath}/${serviceSlug}`;
-
-  // Resolve screenshot URL (Payload Media object or plain string)
-  const screenshotUrl =
-    typeof service.screenshot === "object" && service.screenshot !== null
-      ? service.screenshot.url ?? undefined
-      : service.screenshot ?? undefined;
+  const serviceLink = `/services/${regionPath}/${service.slug}`;
+  const screenshotUrl = getScreenshotUrl(service.screenshot);
 
   const card = getCardColor(colorIndex);
   const shapeName = SERVICE_SHAPES[colorIndex % SERVICE_SHAPES.length]!;
@@ -103,7 +90,7 @@ export async function ServiceCard({
           )}
           {/* Region badge floated top-right */}
           <div className="absolute top-3 right-3">
-            <RegionBadge region={service.region || "eu"} />
+            <RegionBadge region={service.region} />
           </div>
         </div>
 

--- a/apps/website/lib/services.ts
+++ b/apps/website/lib/services.ts
@@ -192,37 +192,8 @@ export function hasSecurityData(service: Service): boolean {
 /**
  * Returns the affiliate URL if set, otherwise the direct service URL.
  */
-export function getOutboundUrl(service: Service): string {
+export function getOutboundUrl(
+  service: Pick<Service, "url" | "affiliateUrl">
+): string {
   return service.affiliateUrl || service.url;
-}
-
-/**
- * Maps a `Service` document to the flat shape expected by `ServiceCard`.
- *
- * @param service - The full Payload Service document (depth 1).
- * @param fallbackCategorySlug - Used when the category relation is not
- *   populated (depth 0 / numeric id).
- */
-export function toServiceCard(
-  service: Service,
-  fallbackCategorySlug: string
-) {
-  return {
-    name: service.name,
-    slug: service.slug,
-    category:
-      typeof service.category === "object"
-        ? service.category.slug
-        : fallbackCategorySlug,
-    location: service.location,
-    region: service.region as "eu" | "non-eu" | "eu-friendly",
-    freeOption: service.freeOption ?? false,
-    startingPrice: service.startingPrice ?? undefined,
-    description: service.description,
-    url: service.url,
-    screenshot: getScreenshotUrl(service.screenshot),
-    features: service.features?.map((f) => f.feature) ?? [],
-    tags: service.tags?.map((t) => t.tag) ?? [],
-    featured: service.featured ?? false,
-  };
 }

--- a/packages/i18n/messages/website/en.json
+++ b/packages/i18n/messages/website/en.json
@@ -511,7 +511,7 @@
         "title": "Recommended Alternative",
         "startingPrice": "Starting Price",
         "migrateFrom": "Migrate {source} To {target}",
-        "viewDetails": "View Service Details",
+        "learnMore": "Learn more",
         "badge": "Recommended by Switch-to.eu",
         "featured": "Featured"
       }

--- a/packages/i18n/messages/website/nl.json
+++ b/packages/i18n/messages/website/nl.json
@@ -505,7 +505,7 @@
         "title": "Aanbevolen alternatief",
         "startingPrice": "Startprijs",
         "migrateFrom": "Migreer van {source} naar {target}",
-        "viewDetails": "Bekijk dienstdetails",
+        "learnMore": "Meer info",
         "badge": "Aanbevolen door Switch-to.eu",
         "featured": "Uitgelicht"
       }


### PR DESCRIPTION
Featured service card on category pages now mirrors the redesigned
detail-page CTA pattern. Outbound clicks route through affiliateUrl
when set, the primary button uses the action-oriented "Try {service}"
label, the secondary becomes a short "Learn more" link to the detail
page, and the affiliate disclosure renders below when applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an external "Try service" outbound link and conditional affiliate disclosure for recommended services
  * Other alternatives list now excludes the recommended service to avoid duplicates

* **UI/UX Updates**
  * CTA label changed to "Learn more"
  * Migration CTA styling switched to an outlined variant
  * Simplified action layout for recommended services (single internal "Learn more" + optional external link)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->