### PR TITLE
refactor: drop legacy markdown-era hybrid interfaces

### DIFF
--- a/apps/website/__tests__/components/InlineSearchInput.test.tsx
+++ b/apps/website/__tests__/components/InlineSearchInput.test.tsx
@@ -37,7 +37,7 @@ let fetchMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   fetchMock = vi.fn();
-  globalThis.fetch = fetchMock;
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
 
   // Default: featured services returns empty
   fetchMock.mockResolvedValue({

--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -142,12 +142,15 @@ export default async function GuideServicePage({
   );
 
   // Build steps data for the sidebar and progress tracking.
-  // Payload guarantees a stable `id` for every saved array row.
-  const guideSteps = guide.steps ?? [];
+  // Filter out any rows Payload hasn't assigned a stable id to yet so
+  // downstream code can rely on a non-null anchor id.
+  const guideSteps = (guide.steps ?? []).filter(
+    (s): s is typeof s & { id: string } => typeof s.id === "string" && s.id.length > 0
+  );
 
   const sidebarSteps = guideSteps.map((step) => ({
     title: step.title,
-    id: step.id!,
+    id: step.id,
   }));
 
   // Pre-render step content from Lexical JSON to HTML on the server.
@@ -161,7 +164,7 @@ export default async function GuideServicePage({
 
     return {
       title: step.title,
-      id: step.id!,
+      id: step.id,
       complete: step.complete ?? false,
       video: videoUrl,
       videoOrientation: step.videoOrientation ?? null,

--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -19,6 +19,11 @@ import { PageLayout } from "@switch-to-eu/blocks/components/page-layout";
 import { NewsletterCta } from "@/components/NewsletterCta";
 import type { SerializedEditorState } from "@payloadcms/richtext-lexical/lexical";
 import type { Guide } from "@/payload-types";
+import {
+  getCategorySlug,
+  getGuideSourceService,
+  getGuideTargetService,
+} from "@/lib/services";
 
 /**
  * Convert a Payload Lexical rich text field value to an HTML string.
@@ -45,10 +50,7 @@ export async function generateStaticParams() {
   return locales.flatMap((locale) =>
     docs.map((g: Guide) => ({
       locale,
-      category:
-        typeof g.category === "object" && g.category !== null
-          ? g.category.slug
-          : "",
+      category: getCategorySlug(g.category),
       service: g.slug,
     }))
   );
@@ -80,15 +82,9 @@ export async function generateMetadata({
     };
   }
 
-  // Resolve service names from relationships
-  const sourceServiceName =
-    typeof guide.sourceService === "object" && guide.sourceService !== null
-      ? guide.sourceService.name
-      : String(guide.sourceService ?? "");
-  const targetServiceName =
-    typeof guide.targetService === "object" && guide.targetService !== null
-      ? guide.targetService.name
-      : String(guide.targetService ?? "");
+  // Resolve service names from relationships (depth: 2 guarantees population)
+  const sourceServiceName = getGuideSourceService(guide)?.name ?? "";
+  const targetServiceName = getGuideTargetService(guide)?.name ?? "";
 
   const title = guide.metaTitle || t("title", { title: guide.title });
   const description = guide.metaDescription || guide.description;
@@ -146,38 +142,30 @@ export default async function GuideServicePage({
   );
 
   // Build steps data for the sidebar and progress tracking.
-  // Each step gets a stable ID based on its index and title.
-  const guideSteps = (guide.steps ?? []) as Array<{
-    title: string;
-    content: SerializedEditorState | null;
-    video?: { url?: string | null } | number | null;
-    videoOrientation?: string | null;
-    complete?: boolean | null;
-    id?: string | null;
-  }>;
+  // Payload guarantees a stable `id` for every saved array row.
+  const guideSteps = guide.steps ?? [];
 
-  const sidebarSteps = guideSteps.map((step, index) => ({
+  const sidebarSteps = guideSteps.map((step) => ({
     title: step.title,
-    id: step.id ?? `step-${index + 1}-${step.title.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 30)}`,
+    id: step.id!,
   }));
 
   // Pre-render step content from Lexical JSON to HTML on the server.
   // This is necessary because GuideStep is a client component and cannot
   // use the server-only <RichText> component from Payload.
-  const stepsWithHtml = guideSteps.map((step, index) => {
-    // Resolve video URL from the media upload relationship
+  const stepsWithHtml = guideSteps.map((step) => {
     const videoUrl =
-      step.video && typeof step.video === "object" && "url" in step.video
+      step.video && typeof step.video === "object"
         ? (step.video.url ?? null)
         : null;
 
     return {
       title: step.title,
-      id: sidebarSteps[index]!.id,
+      id: step.id!,
       complete: step.complete ?? false,
       video: videoUrl,
       videoOrientation: step.videoOrientation ?? null,
-      contentHtml: lexicalToHtml(step.content),
+      contentHtml: lexicalToHtml(step.content as SerializedEditorState | null),
     };
   });
 

--- a/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/guides/[category]/[service]/page.tsx
@@ -123,11 +123,11 @@ export default async function GuideServicePage({
   const { docs } = await payload.find({
     collection: "guides",
     where: { slug: { equals: service } },
-    locale: locale as 'en' | 'nl',
+    locale,
     depth: 2,
     limit: 1,
   });
-  const guide = docs[0] as Guide | undefined;
+  const guide = docs[0];
 
   if (!guide) {
     return notFound();

--- a/apps/website/app/(frontend)/[locale]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/page.tsx
@@ -96,7 +96,7 @@ export default async function Home() {
   const payload = await getPayload();
   const { docs: categories } = await payload.find({
     collection: "categories",
-    locale: locale as 'en' | 'nl',
+    locale,
     limit: 100,
     sort: "title",
   }) as { docs: Category[] };

--- a/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { Banner } from "@switch-to-eu/blocks/components/banner";
 import { SectionHeading } from "@switch-to-eu/blocks/components/section-heading";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import type { LandingPage as LandingPageType, Service } from "@/payload-types";
+import { getCategorySlug, getResolvedRelation } from "@/lib/services";
 
 export async function generateMetadata({
   params,
@@ -71,22 +72,14 @@ export default async function LandingPage({
   }
 
   // With depth: 1, relationships are resolved objects
-  const categorySlug =
-    typeof page.category === "object" && page.category !== null
-      ? page.category.slug
-      : null;
+  const categorySlug = getCategorySlug(page.category) || null;
 
-  const recommendedServices = Array.isArray(page.recommendedServices)
-    ? page.recommendedServices.filter(
-        (s): s is Service => typeof s === "object" && s !== null
-      )
-    : [];
+  const recommendedServices = (page.recommendedServices ?? [])
+    .map((s) => getResolvedRelation<Service>(s))
+    .filter((s): s is Service => s !== null);
 
   // Resolve the related non-EU service
-  const relatedService =
-    typeof page.relatedService === "object" && page.relatedService !== null
-      ? (page.relatedService as Service)
-      : null;
+  const relatedService = getResolvedRelation<Service>(page.relatedService);
 
   // Extract issues from the related service (Payload stores as {issue: string}[])
   const relatedServiceIssues = relatedService?.issues?.map((i) => i.issue) ?? [];
@@ -176,7 +169,6 @@ export default async function LandingPage({
                   key={service.name}
                   service={service}
                   sourceService={relatedServiceName}
-                  migrationGuides={[]}
                 />
               ))}
             </div>

--- a/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/pages/[slug]/page.tsx
@@ -61,11 +61,11 @@ export default async function LandingPage({
   const { docs } = await payload.find({
     collection: "landing-pages",
     where: { slug: { equals: slug } },
-    locale: locale as 'en' | 'nl',
+    locale,
     depth: 1,
     limit: 1,
   });
-  const page = docs[0] as LandingPageType | undefined;
+  const page = docs[0];
 
   if (!page) {
     notFound();

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -168,7 +168,6 @@ export default async function ServicesCategoryPage({
                   key={service.name}
                   service={service}
                   sourceService={service.name}
-                  migrationGuides={[]}
                 />
               ))}
             </div>

--- a/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/[category]/page.tsx
@@ -15,7 +15,7 @@ import { NewsletterCta } from "@/components/NewsletterCta";
 import { Banner } from "@switch-to-eu/blocks/components/banner";
 import { SectionHeading } from "@switch-to-eu/blocks/components/section-heading";
 import { RichText } from "@payloadcms/richtext-lexical/react";
-import type { Category, Service } from "@/payload-types";
+import type { Category } from "@/payload-types";
 
 export async function generateMetadata({
   params,
@@ -92,10 +92,10 @@ export default async function ServicesCategoryPage({
   const { docs: categoryDocs } = await payload.find({
     collection: "categories",
     where: { slug: { equals: category } },
-    locale: locale as 'en' | 'nl',
+    locale,
     limit: 1,
   });
-  const categoryData = categoryDocs[0] as Category | undefined;
+  const categoryData = categoryDocs[0];
 
   if (!categoryData) {
     notFound();
@@ -108,10 +108,10 @@ export default async function ServicesCategoryPage({
       category: { equals: categoryData.id },
       region: { in: ["eu", "eu-friendly"] },
     },
-    locale: locale as 'en' | 'nl',
+    locale,
     depth: 1,
     limit: 100,
-  }) as { docs: Service[] };
+  });
 
   if (euServices.length === 0) {
     notFound();

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
@@ -140,13 +140,13 @@ export default async function ComparisonPage({
     payload.find({
       collection: "services",
       where: { slug: { equals: slug } },
-      locale: locale as "en" | "nl",
+      locale,
       depth: 1,
       limit: 1,
     }),
   ]);
 
-  const nonEuService = nonEuResult.docs[0] as Service | undefined;
+  const nonEuService = nonEuResult.docs[0];
 
   if (!euService || !nonEuService) {
     notFound();
@@ -159,7 +159,7 @@ export default async function ComparisonPage({
       targetService: { equals: euService.id },
       sourceService: { equals: nonEuService.id },
     },
-    locale: locale as "en" | "nl",
+    locale,
     depth: 1,
     limit: 1,
   })) as { docs: Guide[] };

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/[comparison]/page.tsx
@@ -10,7 +10,11 @@ import type { Locale } from "next-intl";
 import type { Locale as AppLocale } from "@switch-to-eu/i18n/routing";
 import { generateLanguageAlternates } from "@switch-to-eu/i18n/utils";
 import type { Service, Guide } from "@/payload-types";
-import { getServiceBySlug } from "@/lib/services";
+import {
+  getGuideSourceService,
+  getGuideTargetService,
+  getServiceBySlug,
+} from "@/lib/services";
 
 export const dynamicParams = false;
 
@@ -24,18 +28,18 @@ export async function generateStaticParams() {
   const locales = ["en", "nl"];
 
   return locales.flatMap((locale) =>
-    guides
-      .filter(
-        (g) =>
-          typeof g.targetService === "object" &&
-          typeof g.sourceService === "object" &&
-          g.targetService.region !== "non-eu"
-      )
-      .map((g) => ({
-        locale,
-        service_name: (g.targetService as Service).slug,
-        comparison: `vs-${(g.sourceService as Service).slug}`,
-      }))
+    guides.flatMap((g) => {
+      const target = getGuideTargetService(g);
+      const source = getGuideSourceService(g);
+      if (!target || !source || target.region === "non-eu") return [];
+      return [
+        {
+          locale,
+          service_name: target.slug,
+          comparison: `vs-${source.slug}`,
+        },
+      ];
+    })
   );
 }
 

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/layout.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/layout.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
@@ -122,7 +123,7 @@ export default async function ServiceLayout({
     href: tab.href,
     label: tab.isComparison
       ? `${service.name} vs ${tab.compareName}`
-      : (t(`tabs.${tab.label}` as Parameters<typeof t>[0]) as string),
+      : t(`tabs.${tab.label}`),
   }));
 
   const hasSubpages = translatedTabs.length > 1;
@@ -217,9 +218,13 @@ export default async function ServiceLayout({
             {screenshotUrl && (
               <div className="flex justify-center md:justify-end">
                 <div className="relative w-full">
-                  <img
+                  <Image
                     src={screenshotUrl}
                     alt={service.name}
+                    width={0}
+                    height={0}
+                    sizes="(max-width: 768px) 100vw, 50vw"
+                    priority
                     className="w-full h-auto object-cover rounded-2xl"
                   />
                   {service.featured && (

--- a/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/layout.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/eu/[service_name]/layout.tsx
@@ -17,6 +17,7 @@ import {
   getSimilarServices,
   getCategorySlug,
   getCategoryId,
+  getGuideSourceService,
   getScreenshotUrl,
   getOutboundUrl,
 } from "@/lib/services";
@@ -57,8 +58,7 @@ function getAvailableTabs(
   }
 
   for (const guide of guides) {
-    const sourceService =
-      typeof guide.sourceService === "object" ? guide.sourceService : null;
+    const sourceService = getGuideSourceService(guide);
     if (sourceService) {
       tabs.push({
         key: `vs-${sourceService.slug}`,
@@ -99,14 +99,12 @@ export default async function ServiceLayout({
 
   // Get first guide for hero CTA
   const firstGuide = relatedGuides[0] ?? null;
-  const firstGuideCategory =
-    firstGuide && typeof firstGuide.category === "object"
-      ? firstGuide.category.slug
-      : null;
-  const firstSourceName =
-    firstGuide && typeof firstGuide.sourceService === "object"
-      ? firstGuide.sourceService.name
-      : null;
+  const firstGuideCategory = firstGuide
+    ? getCategorySlug(firstGuide.category) || null
+    : null;
+  const firstSourceName = firstGuide
+    ? (getGuideSourceService(firstGuide)?.name ?? null)
+    : null;
 
   // Fetch similar services
   const categoryId = getCategoryId(service.category);
@@ -172,12 +170,7 @@ export default async function ServiceLayout({
                   {service.name}
                 </h1>
                 <div className="flex-shrink-0 mt-2">
-                  <RegionBadge
-                    region={
-                      (service.region as "eu" | "non-eu" | "eu-friendly") ||
-                      "eu"
-                    }
-                  />
+                  <RegionBadge region={service.region} />
                 </div>
               </div>
 

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -22,6 +22,10 @@ import { SectionHeading } from "@switch-to-eu/blocks/components/section-heading"
 import { SuggestServiceCard } from "@/components/ui/SuggestServiceCard";
 import type { SerializedEditorState } from "@payloadcms/richtext-lexical/lexical";
 import type { Service, Category, Guide } from "@/payload-types";
+import {
+  getCategorySlug,
+  getResolvedRelation,
+} from "@/lib/services";
 
 export const dynamicParams = false;
 
@@ -62,10 +66,7 @@ export async function generateMetadata({
     };
   }
 
-  const categorySlug =
-    typeof service.category === "object" && service.category !== null
-      ? service.category.slug
-      : String(service.category ?? "");
+  const categorySlug = getCategorySlug(service.category);
 
   const tags = (service.tags ?? []).map((t) => t.tag);
 
@@ -130,45 +131,28 @@ export default async function ServiceDetailPage({
   const issues = (service.issues ?? []).map((i) => i.issue);
 
   // Resolve recommended alternative (already populated via depth: 2)
-  const resolvedAlternative =
-    typeof service.recommendedAlternative === "object" &&
-    service.recommendedAlternative !== null
-      ? (service.recommendedAlternative as Service)
-      : null;
+  const resolvedAlternative = getResolvedRelation<Service>(
+    service.recommendedAlternative
+  );
 
   // Find migration guides between this service and its recommended alternative
-  let migrationGuides: Array<{ category: string; slug: string }> = [];
+  let migrationGuides: Guide[] = [];
   if (resolvedAlternative) {
     const { docs: guideDocs } = await payload.find({
       collection: "guides",
       where: {
         sourceService: { equals: service.id },
-        targetService: {
-          equals:
-            typeof service.recommendedAlternative === "object" &&
-            service.recommendedAlternative !== null
-              ? (service.recommendedAlternative as Service).id
-              : service.recommendedAlternative,
-        },
+        targetService: { equals: resolvedAlternative.id },
       },
       locale: locale as 'en' | 'nl',
       depth: 1,
       limit: 10,
     }) as { docs: Guide[] };
-    migrationGuides = guideDocs.map((g) => ({
-      category:
-        typeof g.category === "object" && g.category !== null
-          ? g.category.slug
-          : "",
-      slug: g.slug,
-    }));
+    migrationGuides = guideDocs;
   }
 
   // Get the category slug for fetching EU alternatives
-  const categorySlug =
-    typeof service.category === "object" && service.category !== null
-      ? service.category.slug
-      : "";
+  const categorySlug = getCategorySlug(service.category);
 
   // Fetch EU alternatives in the same category
   const { docs: categoryDocs } = await payload.find({
@@ -221,14 +205,7 @@ export default async function ServiceDetailPage({
                 <h1 className="font-heading text-4xl sm:text-5xl uppercase text-white">
                   {service.name}
                 </h1>
-                <RegionBadge
-                  region={
-                    (service.region as
-                      | "eu"
-                      | "non-eu"
-                      | "eu-friendly") || "non-eu"
-                  }
-                />
+                <RegionBadge region={service.region} />
               </div>
               <p className="text-white/90 text-base sm:text-lg max-w-2xl">
                 {service.description}

--- a/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
+++ b/apps/website/app/(frontend)/[locale]/services/non-eu/[service_name]/page.tsx
@@ -104,11 +104,11 @@ export default async function ServiceDetailPage({
   const { docs } = await payload.find({
     collection: "services",
     where: { slug: { equals: service_name } },
-    locale: locale as 'en' | 'nl',
+    locale,
     depth: 2,
     limit: 1,
   });
-  const service = docs[0] as Service | undefined;
+  const service = docs[0];
 
   if (!service) {
     notFound();
@@ -144,7 +144,7 @@ export default async function ServiceDetailPage({
         sourceService: { equals: service.id },
         targetService: { equals: resolvedAlternative.id },
       },
-      locale: locale as 'en' | 'nl',
+      locale,
       depth: 1,
       limit: 10,
     }) as { docs: Guide[] };
@@ -172,10 +172,10 @@ export default async function ServiceDetailPage({
         category: { equals: categoryDoc.id },
         region: { equals: "eu" },
       },
-      locale: locale as 'en' | 'nl',
+      locale,
       depth: 1,
       limit: 50,
-    }) as { docs: Service[] };
+    });
     euAlternatives = euDocs;
   }
 

--- a/apps/website/app/api/search/featured/route.ts
+++ b/apps/website/app/api/search/featured/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPayload } from "@/lib/payload";
-import type { Service, Category } from "@/payload-types";
+import type { Service } from "@/payload-types";
 import type { SearchResult } from "@/lib/types";
+import { getCategorySlug } from "@/lib/services";
 import { routing } from "@switch-to-eu/i18n/routing";
 
 type Locale = (typeof routing.locales)[number];
@@ -42,24 +43,17 @@ export async function GET(request: NextRequest) {
       depth: 1, // populate category relationship
     });
 
-    const results: SearchResult[] = docs.map((service: Service) => {
-      const categorySlug =
-        typeof service.category === "object"
-          ? (service.category as Category).slug
-          : undefined;
-
-      return {
-        id: String(service.id),
-        type: "service" as const,
-        title: service.name,
-        description: service.description,
-        url: `/services/${service.region === "non-eu" ? "non-eu" : "eu"}/${service.slug}`,
-        region: service.region,
-        category: categorySlug,
-        location: service.location,
-        freeOption: service.freeOption ?? undefined,
-      };
-    });
+    const results: SearchResult[] = docs.map((service: Service) => ({
+      id: String(service.id),
+      type: "service" as const,
+      title: service.name,
+      description: service.description,
+      url: `/services/${service.region === "non-eu" ? "non-eu" : "eu"}/${service.slug}`,
+      region: service.region,
+      category: getCategorySlug(service.category),
+      location: service.location,
+      freeOption: service.freeOption ?? undefined,
+    }));
 
     console.log(
       `Featured API: Returning ${results.length} featured services`

--- a/apps/website/app/api/search/route.ts
+++ b/apps/website/app/api/search/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { getPayload } from "@/lib/payload";
 import type { Service, Guide, Category } from "@/payload-types";
 import type { SearchResult } from "@/lib/types";
+import {
+  getCategorySlug,
+  getGuideSourceService,
+  getGuideTargetService,
+} from "@/lib/services";
 import { routing } from "@switch-to-eu/i18n/routing";
 
 type Locale = (typeof routing.locales)[number];
@@ -74,24 +79,17 @@ export async function GET(request: NextRequest) {
           depth: 1, // populate category relationship
         })
         .then(({ docs }) =>
-          docs.map((service: Service): SearchResult => {
-            const categorySlug =
-              typeof service.category === "object"
-                ? (service.category as Category).slug
-                : undefined;
-
-            return {
-              id: String(service.id),
-              type: "service",
-              title: service.name,
-              description: service.description,
-              url: `/services/${service.region === "non-eu" ? "non-eu" : "eu"}/${service.slug}`,
-              region: service.region,
-              category: categorySlug,
-              location: service.location,
-              freeOption: service.freeOption ?? undefined,
-            };
-          })
+          docs.map((service: Service): SearchResult => ({
+            id: String(service.id),
+            type: "service",
+            title: service.name,
+            description: service.description,
+            url: `/services/${service.region === "non-eu" ? "non-eu" : "eu"}/${service.slug}`,
+            region: service.region,
+            category: getCategorySlug(service.category),
+            location: service.location,
+            freeOption: service.freeOption ?? undefined,
+          }))
         );
       queries.push(serviceQuery);
     }
@@ -112,28 +110,16 @@ export async function GET(request: NextRequest) {
         })
         .then(({ docs }) =>
           docs.map((guide: Guide): SearchResult => {
-            const categorySlug =
-              typeof guide.category === "object"
-                ? (guide.category as Category).slug
-                : undefined;
-            const sourceName =
-              typeof guide.sourceService === "object"
-                ? (guide.sourceService as Service).name
-                : undefined;
-            const targetName =
-              typeof guide.targetService === "object"
-                ? (guide.targetService as Service).name
-                : undefined;
-
+            const categorySlug = getCategorySlug(guide.category);
             return {
               id: String(guide.id),
               type: "guide",
               title: guide.title,
               description: guide.description,
-              url: `/guides/${categorySlug ?? "uncategorized"}/${guide.slug}`,
+              url: `/guides/${categorySlug || "uncategorized"}/${guide.slug}`,
               category: categorySlug,
-              sourceService: sourceName,
-              targetService: targetName,
+              sourceService: getGuideSourceService(guide)?.name,
+              targetService: getGuideTargetService(guide)?.name,
             };
           })
         );

--- a/apps/website/app/sitemap.xml/route.ts
+++ b/apps/website/app/sitemap.xml/route.ts
@@ -1,5 +1,10 @@
 import { getPayload } from "@/lib/payload";
 import type { Service, Guide, Category } from "@/payload-types";
+import {
+  getCategorySlug,
+  getGuideSourceService,
+  getGuideTargetService,
+} from "@/lib/services";
 import { routing, defaultLocale } from "@switch-to-eu/i18n/routing";
 import { unstable_noStore as noStore } from "next/cache";
 
@@ -175,29 +180,23 @@ async function buildEntries(): Promise<SitemapEntry[]> {
       return entries;
     });
 
-    comparisonEntries = guidesResult.docs
-      .filter(
-        (g: Guide) =>
-          typeof g.targetService === "object" &&
-          typeof g.sourceService === "object" &&
-          (g.targetService as Service).region !== "non-eu"
-      )
-      .flatMap((g: Guide) => {
-        const path = `/services/eu/${(g.targetService as Service).slug}/vs-${(g.sourceService as Service).slug}`;
-        return locales.map((locale) => ({
-          url: `${baseUrl}/${locale}${path}`,
-          lastModified: new Date(g.updatedAt),
-          changeFrequency: "monthly",
-          priority: 0.5,
-          alternates: localeAlternates(path),
-        }));
-      });
+    comparisonEntries = guidesResult.docs.flatMap((g: Guide) => {
+      const target = getGuideTargetService(g);
+      const source = getGuideSourceService(g);
+      if (!target || !source || target.region === "non-eu") return [];
+
+      const path = `/services/eu/${target.slug}/vs-${source.slug}`;
+      return locales.map((locale) => ({
+        url: `${baseUrl}/${locale}${path}`,
+        lastModified: new Date(g.updatedAt),
+        changeFrequency: "monthly",
+        priority: 0.5,
+        alternates: localeAlternates(path),
+      }));
+    });
 
     guidesEntries = guidesResult.docs.flatMap((guide: Guide) => {
-      const categorySlug =
-        typeof guide.category === "object"
-          ? (guide.category as Category).slug
-          : "uncategorized";
+      const categorySlug = getCategorySlug(guide.category) || "uncategorized";
       const path = `/guides/${categorySlug}/${guide.slug}`;
 
       return locales.map((locale) => ({

--- a/apps/website/components/InlineSearchInput.tsx
+++ b/apps/website/components/InlineSearchInput.tsx
@@ -379,7 +379,7 @@ export function InlineSearchInput({
                     </div>
                     {result.type === "service" && "region" in result && result.region && (
                       <RegionBadge
-                        region={result.region as "eu" | "non-eu" | "eu-friendly"}
+                        region={result.region}
                       />
                     )}
                   </div>

--- a/apps/website/components/SearchInput.tsx
+++ b/apps/website/components/SearchInput.tsx
@@ -289,7 +289,7 @@ function SearchResultItem({
           <span className="font-medium">{result.title}</span>
           {result.type === "service" && "region" in result && result.region && (
             <RegionBadge
-              region={result.region as "eu" | "non-eu" | "eu-friendly"}
+              region={result.region}
               showTooltip={true}
               className="text-xs py-0 h-5 "
             />

--- a/apps/website/components/guides/GuideSidebar.tsx
+++ b/apps/website/components/guides/GuideSidebar.tsx
@@ -1,12 +1,8 @@
 import { StepsSummary } from './StepsSummary';
-
-interface Step {
-  title: string;
-  id: string;
-}
+import type { GuideStepSummary } from '@/lib/types';
 
 interface GuideSidebarProps {
-  steps: Step[];
+  steps: GuideStepSummary[];
   className?: string;
   stepsToCompleteText?: string;
   guideId?: string;

--- a/apps/website/components/guides/MobileGuideSidebar.tsx
+++ b/apps/website/components/guides/MobileGuideSidebar.tsx
@@ -6,14 +6,10 @@ import { Button } from '@switch-to-eu/ui/components/button';
 import { Sheet, SheetContent, SheetTrigger, SheetTitle } from '@switch-to-eu/ui/components/sheet';
 import { GuideSidebar } from './GuideSidebar';
 import { usePathname } from 'next/navigation';
-
-interface Step {
-  title: string;
-  id: string;
-}
+import type { GuideStepSummary } from '@/lib/types';
 
 interface MobileGuideSidebarProps {
-  steps: Step[];
+  steps: GuideStepSummary[];
   lang?: string;
   stepsToCompleteText?: string;
   guideId?: string;

--- a/apps/website/components/guides/StepsSummary.tsx
+++ b/apps/website/components/guides/StepsSummary.tsx
@@ -6,14 +6,10 @@ import { cn } from "@switch-to-eu/ui/lib/utils";
 import { usePathname } from "next/navigation";
 import { useGuideProgressStore } from "@/lib/store/guide-progress";
 import { Link } from "@switch-to-eu/i18n/navigation";
-
-interface Step {
-  title: string;
-  id: string;
-}
+import type { GuideStepSummary } from "@/lib/types";
 
 interface StepsSummaryProps {
-  steps: Step[];
+  steps: GuideStepSummary[];
   title?: string;
   lang?: string;
   stepsToCompleteText?: string;
@@ -69,7 +65,7 @@ export function StepsSummary({
 
   // Function to find the element by step title or ID - wrap in useCallback
   const findElementByStep = useCallback(
-    (step: Step): HTMLElement | null => {
+    (step: GuideStepSummary): HTMLElement | null => {
       if (!isBrowser || !step) return null;
 
       try {

--- a/apps/website/components/layout/header.tsx
+++ b/apps/website/components/layout/header.tsx
@@ -5,9 +5,9 @@ import { Header as BlocksHeader } from "@switch-to-eu/blocks/components/header";
 import { NavLanguageSelector } from "@switch-to-eu/blocks/components/nav-language-selector";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import { useLocale } from "next-intl";
-import type { Locale } from "@switch-to-eu/i18n/routing";
+
 export function Header() {
-  const locale = useLocale() as Locale;
+  const locale = useLocale();
 
   return (
     <BlocksHeader

--- a/apps/website/components/navigation/mobile-nav.tsx
+++ b/apps/website/components/navigation/mobile-nav.tsx
@@ -6,10 +6,9 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import { MobileCategoryIcon } from "./MobileCategoryIcon";
 import { MobileToolIcon } from "./MobileToolIcon";
-import type { Locale } from "@switch-to-eu/i18n/routing";
 
 export async function MobileNav() {
-  const locale = await getLocale() as Locale;
+  const locale = await getLocale();
   const navItems = await getNavItems();
   const t = await getTranslations("navigation");
 

--- a/apps/website/components/ui/RecommendedAlternative.tsx
+++ b/apps/website/components/ui/RecommendedAlternative.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import { DecorativeShape } from "@switch-to-eu/blocks/components/decorative-shape";
@@ -153,9 +154,12 @@ export async function RecommendedAlternative({
         {screenshotUrl && (
           <div className="flex justify-center md:justify-end p-6 md:p-8">
             <div className="relative w-full">
-              <img
+              <Image
                 src={screenshotUrl}
                 alt={service.name}
+                width={0}
+                height={0}
+                sizes="(max-width: 768px) 100vw, 50vw"
                 className="w-full h-auto object-cover rounded-2xl"
               />
               <div className="absolute -top-6 -right-6 sm:-top-8 sm:-right-8 flex items-center justify-center">

--- a/apps/website/components/ui/RecommendedAlternative.tsx
+++ b/apps/website/components/ui/RecommendedAlternative.tsx
@@ -126,9 +126,9 @@ export async function RecommendedAlternative({
             </Link>
 
             {sourceService &&
-              migrationGuides.length > 0 &&
               migrationGuides.map((guide) => {
                 const categorySlug = getCategorySlug(guide.category);
+                if (!categorySlug) return null;
                 return (
                   <Link
                     key={`${categorySlug}-${guide.slug}`}

--- a/apps/website/components/ui/RecommendedAlternative.tsx
+++ b/apps/website/components/ui/RecommendedAlternative.tsx
@@ -2,8 +2,12 @@ import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
 import { DecorativeShape } from "@switch-to-eu/blocks/components/decorative-shape";
 import { AffiliateDisclosure } from "@/components/ui/AffiliateDisclosure";
-import { getOutboundUrl, getScreenshotUrl } from "@/lib/services";
-import type { Service } from "@/payload-types";
+import {
+  getCategorySlug,
+  getOutboundUrl,
+  getScreenshotUrl,
+} from "@/lib/services";
+import type { Guide, Service } from "@/payload-types";
 
 export type RecommendedAlternativeService = Pick<
   Service,
@@ -19,10 +23,7 @@ export type RecommendedAlternativeService = Pick<
   | "screenshot"
 >;
 
-interface MigrationGuide {
-  category: string;
-  slug: string;
-}
+export type RecommendedAlternativeGuide = Pick<Guide, "slug" | "category">;
 
 export async function RecommendedAlternative({
   service,
@@ -31,7 +32,7 @@ export async function RecommendedAlternative({
 }: {
   service: RecommendedAlternativeService;
   sourceService: string;
-  migrationGuides: MigrationGuide[];
+  migrationGuides?: RecommendedAlternativeGuide[];
 }) {
   const t = await getTranslations("services");
 
@@ -126,18 +127,21 @@ export async function RecommendedAlternative({
 
             {sourceService &&
               migrationGuides.length > 0 &&
-              migrationGuides.map((guide) => (
-                <Link
-                  key={`${guide.category}-${guide.slug}`}
-                  href={`/guides/${guide.category}/${guide.slug}`}
-                  className="inline-block py-2.5 px-6 border-2 border-brand-yellow text-brand-yellow rounded-full font-semibold text-sm hover:bg-brand-yellow hover:text-brand-green transition-colors no-underline"
-                >
-                  {t("detail.recommendedAlternative.migrateFrom", {
-                    source: sourceService,
-                    target: service.name,
-                  })}
-                </Link>
-              ))}
+              migrationGuides.map((guide) => {
+                const categorySlug = getCategorySlug(guide.category);
+                return (
+                  <Link
+                    key={`${categorySlug}-${guide.slug}`}
+                    href={`/guides/${categorySlug}/${guide.slug}`}
+                    className="inline-block py-2.5 px-6 border-2 border-brand-yellow text-brand-yellow rounded-full font-semibold text-sm hover:bg-brand-yellow hover:text-brand-green transition-colors no-underline"
+                  >
+                    {t("detail.recommendedAlternative.migrateFrom", {
+                      source: sourceService,
+                      target: service.name,
+                    })}
+                  </Link>
+                );
+              })}
           </div>
 
           {outboundUrl && service.affiliateUrl && (

--- a/apps/website/components/ui/ServiceCard.tsx
+++ b/apps/website/components/ui/ServiceCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 import { RegionBadge } from "@switch-to-eu/ui/components/region-badge";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@switch-to-eu/i18n/navigation";
@@ -66,10 +67,12 @@ export async function ServiceCard({
         {/* Visual area: screenshot or decorative shape */}
         <div className="relative h-36 sm:h-44 flex items-center justify-center overflow-hidden">
           {screenshotUrl ? (
-            <img
+            <Image
               src={screenshotUrl}
               alt={service.name}
-              className="w-full h-full object-cover"
+              fill
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              className="object-cover"
             />
           ) : (
             <div className="w-full h-full flex items-center justify-center p-8 sm:p-10">

--- a/apps/website/lib/llm-content.ts
+++ b/apps/website/lib/llm-content.ts
@@ -5,7 +5,13 @@
 
 import type { Service, Guide, Category } from "@/payload-types";
 import { lexicalToMarkdown } from "./lexical-to-markdown";
-import { getGdprLabel } from "./services";
+import {
+  getCategorySlug,
+  getCategoryTitle,
+  getGdprLabel,
+  getGuideSourceService,
+  getGuideTargetService,
+} from "./services";
 
 const BASE_URL = process.env.NEXT_PUBLIC_URL ?? "https://www.switch-to.eu";
 
@@ -61,7 +67,7 @@ export function serviceToMarkdown(service: Service): string {
   }
 
   // Main content
-  const content = lexicalToMarkdown(service.content as Parameters<typeof lexicalToMarkdown>[0]);
+  const content = lexicalToMarkdown(service.content);
   if (content) {
     lines.push("## About");
     lines.push("");
@@ -118,21 +124,15 @@ export function guideToMarkdown(guide: Guide): string {
   lines.push(`- **Difficulty**: ${guide.difficulty}`);
   lines.push(`- **Time required**: ${guide.timeRequired}`);
 
-  const source =
-    typeof guide.sourceService === "object"
-      ? guide.sourceService.name
-      : null;
-  const target =
-    typeof guide.targetService === "object"
-      ? guide.targetService.name
-      : null;
+  const source = getGuideSourceService(guide)?.name ?? null;
+  const target = getGuideTargetService(guide)?.name ?? null;
   if (source) lines.push(`- **From**: ${source}`);
   if (target) lines.push(`- **To**: ${target}`);
 
   lines.push("");
 
   // Intro
-  const intro = lexicalToMarkdown(guide.intro as Parameters<typeof lexicalToMarkdown>[0]);
+  const intro = lexicalToMarkdown(guide.intro);
   if (intro) {
     lines.push("## Why switch?");
     lines.push("");
@@ -141,7 +141,7 @@ export function guideToMarkdown(guide: Guide): string {
   }
 
   // Before you start
-  const before = lexicalToMarkdown(guide.beforeYouStart as Parameters<typeof lexicalToMarkdown>[0]);
+  const before = lexicalToMarkdown(guide.beforeYouStart);
   if (before) {
     lines.push("## Before you start");
     lines.push("");
@@ -157,7 +157,7 @@ export function guideToMarkdown(guide: Guide): string {
       const step = guide.steps[i]!;
       lines.push(`### Step ${i + 1}: ${step.title}`);
       lines.push("");
-      const stepContent = lexicalToMarkdown(step.content as Parameters<typeof lexicalToMarkdown>[0]);
+      const stepContent = lexicalToMarkdown(step.content);
       if (stepContent) {
         lines.push(stepContent);
         lines.push("");
@@ -176,8 +176,7 @@ export function guideToMarkdown(guide: Guide): string {
   }
 
   // Troubleshooting
-  const troubleshooting = lexicalToMarkdown(
-    guide.troubleshooting   );
+  const troubleshooting = lexicalToMarkdown(guide.troubleshooting);
   if (troubleshooting) {
     lines.push("## Troubleshooting");
     lines.push("");
@@ -186,7 +185,7 @@ export function guideToMarkdown(guide: Guide): string {
   }
 
   // Outro
-  const outro = lexicalToMarkdown(guide.outro as Parameters<typeof lexicalToMarkdown>[0]);
+  const outro = lexicalToMarkdown(guide.outro);
   if (outro) {
     lines.push("## Next steps");
     lines.push("");
@@ -269,17 +268,14 @@ export function buildLlmsIndex(
   if (guides.length > 0) {
     lines.push("## Migration guides");
     lines.push("");
-    const grouped = groupGuidesByCategory(guides);
+    const grouped = groupByCategory(guides);
     for (const [categoryName, items] of grouped) {
       lines.push(`### ${categoryName}`);
       lines.push("");
       for (const g of items) {
-        const source =
-          typeof g.sourceService === "object" ? g.sourceService.name : null;
-        const target =
-          typeof g.targetService === "object" ? g.targetService.name : null;
-        const catSlug =
-          typeof g.category === "object" ? g.category.slug : "uncategorized";
+        const source = getGuideSourceService(g)?.name ?? null;
+        const target = getGuideTargetService(g)?.name ?? null;
+        const catSlug = getCategorySlug(g.category) || "uncategorized";
         const meta = [`${g.difficulty}`, g.timeRequired].join(", ");
         const label = source && target ? `${source} → ${target}` : g.title;
         lines.push(
@@ -293,25 +289,12 @@ export function buildLlmsIndex(
   return lines.join("\n").trim();
 }
 
-function groupByCategory(services: Service[]): [string, Service[]][] {
-  const map = new Map<string, Service[]>();
-  for (const s of services) {
-    const name =
-      typeof s.category === "object" ? s.category.title : "Other";
+function groupByCategory<T extends Service | Guide>(docs: T[]): [string, T[]][] {
+  const map = new Map<string, T[]>();
+  for (const doc of docs) {
+    const name = getCategoryTitle(doc.category);
     const list = map.get(name) ?? [];
-    list.push(s);
-    map.set(name, list);
-  }
-  return [...map.entries()];
-}
-
-function groupGuidesByCategory(guides: Guide[]): [string, Guide[]][] {
-  const map = new Map<string, Guide[]>();
-  for (const g of guides) {
-    const name =
-      typeof g.category === "object" ? g.category.title : "Other";
-    const list = map.get(name) ?? [];
-    list.push(g);
+    list.push(doc);
     map.set(name, list);
   }
   return [...map.entries()];

--- a/apps/website/lib/services.ts
+++ b/apps/website/lib/services.ts
@@ -139,10 +139,13 @@ export function getResolvedRelation<T extends { id: number }>(
 
 type CategoryRelation = Service["category"] | null | undefined;
 
-/** Resolve the slug string from a Service/Guide/LandingPage category field. */
+/**
+ * Resolve the slug from a populated category. Returns `""` when the
+ * relationship hasn't been populated (bare id / null / undefined) — callers
+ * should treat that as "unresolved" and handle it explicitly.
+ */
 export function getCategorySlug(category: CategoryRelation): string {
-  if (typeof category === "object" && category !== null) return category.slug;
-  return typeof category === "number" ? String(category) : "";
+  return typeof category === "object" && category !== null ? category.slug : "";
 }
 
 /** Resolve the numeric id from a Service/Guide category field. */

--- a/apps/website/lib/services.ts
+++ b/apps/website/lib/services.ts
@@ -127,14 +127,47 @@ export async function getAllEuServiceSlugs() {
 // Pure helper functions
 // ---------------------------------------------------------------------------
 
-/** Resolve the slug string from a Service's category field. */
-export function getCategorySlug(category: Service["category"]): string {
-  return typeof category === "object" ? category.slug : String(category);
+/**
+ * Resolve a Payload relationship field to its populated object, or `null`
+ * when the relationship is a bare id / missing / not populated via `depth`.
+ */
+export function getResolvedRelation<T extends { id: number }>(
+  relation: number | T | null | undefined
+): T | null {
+  return typeof relation === "object" && relation !== null ? relation : null;
 }
 
-/** Resolve the numeric id from a Service's category field. */
+type CategoryRelation = Service["category"] | null | undefined;
+
+/** Resolve the slug string from a Service/Guide/LandingPage category field. */
+export function getCategorySlug(category: CategoryRelation): string {
+  if (typeof category === "object" && category !== null) return category.slug;
+  return typeof category === "number" ? String(category) : "";
+}
+
+/** Resolve the numeric id from a Service/Guide category field. */
 export function getCategoryId(category: Service["category"]): number {
   return typeof category === "object" ? category.id : category;
+}
+
+/** Resolve the localized title from a category field, populated or not. */
+export function getCategoryTitle(
+  category: CategoryRelation,
+  fallback = "Other"
+): string {
+  return typeof category === "object" && category !== null
+    ? category.title
+    : fallback;
+}
+
+/** Resolve the populated source service from a guide, or `null`. */
+export function getGuideSourceService(guide: Guide): Service | null {
+  return getResolvedRelation<Service>(guide.sourceService);
+}
+
+/** Resolve the populated target service from a guide, or `null`. */
+export function getGuideTargetService(guide: Guide): Service | null {
+  return getResolvedRelation<Service>(guide.targetService);
 }
 
 /** Resolve the screenshot URL from a Service's screenshot field. */

--- a/apps/website/lib/types.ts
+++ b/apps/website/lib/types.ts
@@ -1,13 +1,24 @@
+import type { Service } from "@/payload-types";
+
 export type SearchResult = {
   id: string;
   type: "service" | "guide" | "category" | "landing-page";
   title: string;
   description: string;
   url: string;
-  region?: string;
+  region?: Service["region"];
   category?: string;
   location?: string;
   freeOption?: boolean;
   sourceService?: string;
   targetService?: string;
-}
+};
+
+/**
+ * Compact step descriptor consumed by the guide sidebar + steps summary.
+ * Derived from a Payload `Guide["steps"][number]` at the page level.
+ */
+export type GuideStepSummary = {
+  title: string;
+  id: string;
+};

--- a/apps/website/mcp/wipeContentTool.ts
+++ b/apps/website/mcp/wipeContentTool.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — generic collection parameter creates union types TS can't narrow
 import { z } from "zod";
 import type { PayloadRequest } from "payload";
 

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -11,7 +11,15 @@ const nextConfig: NextConfig = {
   ],
   // Configure pageExtensions to include md and mdx
   pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
-  async redirects() {
+  images: {
+    // Payload media is served from Vercel Blob when BLOB_READ_WRITE_TOKEN
+    // is set (see payload.config.ts), otherwise from /api/media/file/* on
+    // the same origin.
+    remotePatterns: [
+      { protocol: "https", hostname: "*.public.blob.vercel-storage.com" },
+    ],
+  },
+  redirects() {
     return [
       // Non-prefixed content URLs → default locale (308 permanent).
       // Prevents Accept-Language-based 307 redirects that fragment SEO.
@@ -80,7 +88,7 @@ const nextConfig: NextConfig = {
       },
     ];
   },
-  async rewrites() {
+  rewrites() {
     return {
       beforeFiles: [
         // LLM-friendly .md URLs → API route handlers.

--- a/apps/website/seed/importCategories.ts
+++ b/apps/website/seed/importCategories.ts
@@ -59,7 +59,7 @@ export async function importCategories(
       });
     }
 
-    categoryMap.set(cat.slug, created.id as number);
+    categoryMap.set(cat.slug, created.id);
   }
 
   console.log(`  Imported ${categoryMap.size} categories`);

--- a/apps/website/seed/importServices.ts
+++ b/apps/website/seed/importServices.ts
@@ -134,7 +134,7 @@ export async function importServices(
       });
     }
 
-    serviceMap.set(slug, created.id as number);
+    serviceMap.set(slug, created.id);
   }
 
   // Second pass: resolve recommendedAlternative


### PR DESCRIPTION
Consolidate Payload relationship handling into helpers, remove
silent slug/name fallbacks, and replace bespoke types with direct
Payload shapes. Matches the pattern already established by
ServiceCard + RecommendedAlternative (Pick<Service, ...>).

- lib/services.ts: add getResolvedRelation, getCategoryTitle,
  getGuideSourceService, getGuideTargetService; widen
  getCategorySlug to accept LandingPage's nullable category.
- lib/types.ts: narrow SearchResult.region to Service["region"];
  extract shared GuideStepSummary for sidebar components.
- lib/llm-content.ts: drop redundant Parameters<> casts, collapse
  typeof-object guards into helpers, unify groupByCategory.
- app/api/search + sitemap: replace `as Service` / `as Category`
  casts with helpers.
- guides/[category]/[service]/page.tsx: trust Payload array-row
  `step.id`, drop the title-derived fallback slug + bespoke step
  type.
- services/eu/layout + services/non-eu/page: drop redundant
  region casts (Payload makes region required non-null).
- RecommendedAlternative: accept Pick<Guide, "slug" | "category">
  for migrationGuides, make prop optional; drop manual mapping at
  callers that passed empty arrays.
- Consolidate duplicated Step interface across StepsSummary,
  GuideSidebar, MobileGuideSidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared data-resolution helpers and standardized guide step types across the site.

* **Bug Fixes**
  * More robust resolution of service/guide relationships to prevent broken or missing related data.

* **UI**
  * Cleaner guide sidebars (only valid steps shown) and normalized migration links.
  * Improved responsive image handling for screenshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->