### PR TITLE
feat(website): add language switch banner

### DIFF
--- a/apps/website/app/(frontend)/[locale]/layout.tsx
+++ b/apps/website/app/(frontend)/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import PlausibleProvider from "next-plausible";
 
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
+import { LanguageSwitchBanner } from "@switch-to-eu/blocks/components/language-switch-banner";
 import { routing } from "@switch-to-eu/i18n/routing";
 import { getLocale, getTranslations } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
@@ -110,6 +111,7 @@ export default async function LocaleLayout({
             __html: JSON.stringify(websiteJsonLd),
           }}
         />
+        <LanguageSwitchBanner />
         <Header />
         <main className="flex-1">{children}</main>
         <Footer />

--- a/packages/blocks/src/components/language-switch-banner.tsx
+++ b/packages/blocks/src/components/language-switch-banner.tsx
@@ -1,13 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { X } from "lucide-react";
-import { useLocale, useTranslations } from "next-intl";
+import { createTranslator, useLocale } from "next-intl";
 import { Link, usePathname } from "@switch-to-eu/i18n/navigation";
 import { locales, type Locale } from "@switch-to-eu/i18n/routing";
 import { cn } from "@switch-to-eu/ui/lib/utils";
+import enMessages from "@switch-to-eu/i18n/messages/shared/en.json";
+import nlMessages from "@switch-to-eu/i18n/messages/shared/nl.json";
 
 const DISMISS_KEY = "switch-to-eu:language-banner-dismissed";
+
+const messagesByLocale: Record<Locale, typeof enMessages> = {
+  en: enMessages,
+  nl: nlMessages,
+};
 
 function detectBrowserLocale(
   current: Locale,
@@ -36,9 +43,25 @@ export interface LanguageSwitchBannerProps {
 export function LanguageSwitchBanner({ className }: LanguageSwitchBannerProps) {
   const currentLocale = useLocale() as Locale;
   const pathname = usePathname();
-  const t = useTranslations("languageBanner");
-  const tLang = useTranslations("language");
   const [suggested, setSuggested] = useState<Locale | null>(null);
+
+  const t = useMemo(() => {
+    if (!suggested) return null;
+    return createTranslator({
+      locale: suggested,
+      messages: messagesByLocale[suggested],
+      namespace: "languageBanner",
+    });
+  }, [suggested]);
+
+  const tLang = useMemo(() => {
+    if (!suggested) return null;
+    return createTranslator({
+      locale: suggested,
+      messages: messagesByLocale[suggested],
+      namespace: "language",
+    });
+  }, [suggested]);
 
   useEffect(() => {
     const detected = detectBrowserLocale(currentLocale, locales);
@@ -51,7 +74,7 @@ export function LanguageSwitchBanner({ className }: LanguageSwitchBannerProps) {
     setSuggested(detected);
   }, [currentLocale]);
 
-  if (!suggested) return null;
+  if (!suggested || !t || !tLang) return null;
 
   const dismiss = () => {
     try {

--- a/packages/blocks/src/components/language-switch-banner.tsx
+++ b/packages/blocks/src/components/language-switch-banner.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { Link, usePathname } from "@switch-to-eu/i18n/navigation";
+import { locales, type Locale } from "@switch-to-eu/i18n/routing";
+import { cn } from "@switch-to-eu/ui/lib/utils";
+
+const DISMISS_KEY = "switch-to-eu:language-banner-dismissed";
+
+function detectBrowserLocale(
+  current: Locale,
+  supported: readonly Locale[],
+): Locale | null {
+  if (typeof navigator === "undefined") return null;
+  const candidates =
+    navigator.languages && navigator.languages.length > 0
+      ? navigator.languages
+      : [navigator.language];
+
+  for (const candidate of candidates) {
+    const prefix = candidate.slice(0, 2).toLowerCase();
+    if ((supported as readonly string[]).includes(prefix)) {
+      const match = prefix as Locale;
+      return match === current ? null : match;
+    }
+  }
+  return null;
+}
+
+export interface LanguageSwitchBannerProps {
+  className?: string;
+}
+
+export function LanguageSwitchBanner({ className }: LanguageSwitchBannerProps) {
+  const currentLocale = useLocale() as Locale;
+  const pathname = usePathname();
+  const t = useTranslations("languageBanner");
+  const tLang = useTranslations("language");
+  const [suggested, setSuggested] = useState<Locale | null>(null);
+
+  useEffect(() => {
+    const detected = detectBrowserLocale(currentLocale, locales);
+    if (!detected) return;
+    try {
+      if (localStorage.getItem(DISMISS_KEY) === detected) return;
+    } catch {
+      // localStorage unavailable (private mode, SSR) — just show the banner
+    }
+    setSuggested(detected);
+  }, [currentLocale]);
+
+  if (!suggested) return null;
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, suggested);
+    } catch {
+      // ignore storage failures
+    }
+    setSuggested(null);
+  };
+
+  const languageName = tLang(suggested);
+
+  return (
+    <div
+      role="region"
+      aria-label={t("switch", { language: languageName })}
+      className={cn("bg-brand-navy text-white", className)}
+    >
+      <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-3 px-4 py-2.5 sm:px-6">
+        <p className="text-sm">
+          {t("message", { language: languageName })}
+        </p>
+        <div className="flex items-center gap-2">
+          <Link
+            href={pathname}
+            locale={suggested}
+            className="rounded-full bg-white px-4 py-1.5 text-sm font-semibold text-brand-navy hover:bg-white/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            {t("switch", { language: languageName })}
+          </Link>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={t("dismiss")}
+            className="rounded-full p-1.5 text-white hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/i18n/messages/shared/en.json
+++ b/packages/i18n/messages/shared/en.json
@@ -3,6 +3,11 @@
     "en": "English",
     "nl": "Dutch"
   },
+  "languageBanner": {
+    "message": "This page is also available in {language}.",
+    "switch": "Switch to {language}",
+    "dismiss": "Dismiss"
+  },
   "footer": {
     "copyright": "{year} <link>switch-to.eu</link> — a project by"
   },

--- a/packages/i18n/messages/shared/nl.json
+++ b/packages/i18n/messages/shared/nl.json
@@ -3,6 +3,11 @@
     "en": "English",
     "nl": "Nederlands"
   },
+  "languageBanner": {
+    "message": "Deze pagina is ook beschikbaar in het {language}.",
+    "switch": "Schakel over naar {language}",
+    "dismiss": "Sluiten"
+  },
   "footer": {
     "copyright": "{year} <link>switch-to.eu</link> — een project van"
   },


### PR DESCRIPTION
Detects the visitor's preferred browser locale and prompts them to
switch when it differs from the current page locale. Dismissal is
persisted in localStorage so the banner only reappears if a different
supported locale is detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a language-suggestion banner that automatically detects your browser's language preferences and offers to switch the page to a matching locale if available. You can dismiss the banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->