### PR TITLE
fix(website): serve media direct from Vercel Blob CDN

### DIFF
--- a/apps/website/app/(payload)/admin/importMap.js
+++ b/apps/website/app/(payload)/admin/importMap.js
@@ -22,6 +22,7 @@ import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997e
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { default as default_4f5ea353b95353b3cf387da6385bce43 } from '../../../components/admin/IndexNowButton'
+import { default as default_192965f311159ba4c5910b674ee27549 } from '../../../components/admin/RevalidateCachesButton'
 import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
@@ -51,6 +52,7 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "/components/admin/IndexNowButton#default": default_4f5ea353b95353b3cf387da6385bce43,
+  "/components/admin/RevalidateCachesButton#default": default_192965f311159ba4c5910b674ee27549,
   "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/apps/website/app/api/admin/revalidate-caches/route.ts
+++ b/apps/website/app/api/admin/revalidate-caches/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
   if (authError) return authError;
 
   for (const tag of TAGS) {
-    revalidateTag(tag);
+    revalidateTag(tag, "default");
   }
 
   return Response.json({ revalidated: TAGS });

--- a/apps/website/app/api/admin/revalidate-caches/route.ts
+++ b/apps/website/app/api/admin/revalidate-caches/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { revalidateTag } from "next/cache";
+import { getPayload } from "@/lib/payload";
+
+const TAGS = [
+  "services",
+  "guides",
+  "categories",
+  "pages",
+  "landing-pages",
+] as const;
+
+async function requireAdmin(request: NextRequest) {
+  const payload = await getPayload();
+  const { user } = await payload.auth({ headers: request.headers });
+  if (!user) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  return null;
+}
+
+export async function POST(request: NextRequest) {
+  const authError = await requireAdmin(request);
+  if (authError) return authError;
+
+  for (const tag of TAGS) {
+    revalidateTag(tag);
+  }
+
+  return Response.json({ revalidated: TAGS });
+}

--- a/apps/website/components/admin/RevalidateCachesButton.tsx
+++ b/apps/website/components/admin/RevalidateCachesButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+
+const TAGS = ["services", "guides", "categories", "pages", "landing-pages"];
+
+export default function RevalidateCachesButton() {
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleClick() {
+    setLoading(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/api/admin/revalidate-caches", {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const data = (await res.json()) as { revalidated: string[] };
+      setStatus(`Revalidated: ${data.revalidated.join(", ")}`);
+    } catch (err) {
+      setStatus(`Failed: ${err instanceof Error ? err.message : "unknown"}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        padding: "1rem 1.25rem",
+        border: "1px solid var(--theme-elevation-100)",
+        borderRadius: 6,
+        marginBottom: "1.5rem",
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.75rem",
+      }}
+    >
+      <div>
+        <strong>Revalidate caches</strong>
+        <div style={{ fontSize: 13, color: "var(--theme-elevation-500)" }}>
+          Bust the Next.js data cache for {TAGS.join(", ")}. Use after changing
+          media URL config or other cached fields.
+        </div>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+        <button
+          type="button"
+          onClick={handleClick}
+          disabled={loading}
+          className="btn btn--style-primary"
+          style={{ alignSelf: "flex-start" }}
+        >
+          {loading ? "Revalidating…" : "Revalidate all caches"}
+        </button>
+        {status && <span style={{ fontSize: 13 }}>{status}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/website/payload.config.ts
+++ b/apps/website/payload.config.ts
@@ -29,7 +29,10 @@ export default buildConfig({
       baseDir: path.resolve(__dirname),
     },
     components: {
-      beforeDashboard: ["/components/admin/IndexNowButton"],
+      beforeDashboard: [
+        "/components/admin/IndexNowButton",
+        "/components/admin/RevalidateCachesButton",
+      ],
     },
   },
   db: postgresAdapter({
@@ -78,6 +81,7 @@ export default buildConfig({
             collections: {
               media: {
                 prefix: process.env.VERCEL_ENV ?? "local",
+                disablePayloadAccessControl: true,
               },
             },
             token: process.env.BLOB_READ_WRITE_TOKEN,

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -10,7 +10,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://plausible.io; media-src 'self' https://github.com https://raw.githubusercontent.com" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://plausible.io; media-src 'self' https://github.com https://raw.githubusercontent.com https://*.public.blob.vercel-storage.com" }
       ]
     }
   ],

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -10,7 +10,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://plausible.io; media-src 'self' https://github.com https://raw.githubusercontent.com https://*.public.blob.vercel-storage.com" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io https://vercel.live; style-src 'self' 'unsafe-inline' https://vercel.live; img-src 'self' data: https:; font-src 'self' https://vercel.live https://assets.vercel.com; connect-src 'self' https://plausible.io https://vercel.live wss://ws-us3.pusher.com; frame-src https://vercel.live; media-src 'self' https://github.com https://raw.githubusercontent.com https://*.public.blob.vercel-storage.com" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- All images broke after the Next 16 rebuild — Payload was returning `/api/media/file/<file>?prefix=<env>` URLs, and `next/image` rejects relative URLs with query strings unless they're listed in `images.localPatterns`.
- Setting `disablePayloadAccessControl: true` on the media collection makes Payload's `afterRead` hook return the direct Vercel Blob CDN URL (`https://<store>.public.blob.vercel-storage.com/<prefix>/<file>`) instead. The CDN host is already allowed in `next.config.ts`, and the Media collection is public anyway.
- The cached service/guide docs in `unstable_cache` will keep serving the old URLs until the cache is busted, so this PR also adds an admin "Revalidate caches" button (next to "IndexNow") that hits a new `POST /api/admin/revalidate-caches` and revalidates `services`, `guides`, `categories`, `pages`, `landing-pages`.

## Test plan

- [ ] Local: restart `pnpm --filter website dev`, hit any service/category page, confirm `<img>` `src` is `https://*.public.blob.vercel-storage.com/...` (not `/api/media/file/...`).
- [ ] Local: open `/admin`, click "Revalidate all caches", confirm `Revalidated: services, guides, categories, pages, landing-pages`.
- [ ] Local: confirm `/api/admin/revalidate-caches` returns 401 when unauthenticated.
- [ ] Production after deploy: open `/admin`, click "Revalidate all caches", reload a service detail page, confirm images load and `src` points at the blob CDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)