### PR TITLE
chore(website): drop GitHub hosts from CSP media-src

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -10,7 +10,7 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io https://vercel.live; style-src 'self' 'unsafe-inline' https://vercel.live; img-src 'self' data: https:; font-src 'self' https://vercel.live https://assets.vercel.com; connect-src 'self' https://plausible.io https://vercel.live wss://ws-us3.pusher.com; frame-src https://vercel.live; media-src 'self' https://github.com https://raw.githubusercontent.com https://*.public.blob.vercel-storage.com" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://plausible.io https://vercel.live; style-src 'self' 'unsafe-inline' https://vercel.live; img-src 'self' data: https:; font-src 'self' https://vercel.live https://assets.vercel.com; connect-src 'self' https://plausible.io https://vercel.live wss://ws-us3.pusher.com; frame-src https://vercel.live; media-src 'self' https://*.public.blob.vercel-storage.com" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- All video assets are served from the Vercel Blob CDN now (verified via grep — only outbound links to github.com remain, no embedded media).
- Removes `https://github.com` and `https://raw.githubusercontent.com` from `media-src`.

## Test plan

- [ ] Open a guide with embedded video (e.g. gmail-to-protonmail) on the preview deploy and confirm videos still play with no CSP errors in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)