### PR TITLE
chore(repo): skip skilld prepare in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "turbo run start",
     "lint": "turbo run lint",
     "clean": "turbo run clean",
-    "prepare": "npx skilld prepare || true"
+    "prepare": "[ -n \"$CI\" ] || npx skilld prepare || true"
   },
   "devDependencies": {
     "turbo": "^2.9.6"


### PR DESCRIPTION
CI environments (Vercel, GitHub Actions) set $CI=true. The skill sync only matters during local dev, so guard the prepare hook to skip it on CI installs and shave a noisy network-bound step off every deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script configuration to skip the prepare step in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->