### PR TITLE
fix(sitemap): exclude noindex service subpages from sitemap.xml

### DIFF
--- a/apps/website/app/sitemap.xml/route.ts
+++ b/apps/website/app/sitemap.xml/route.ts
@@ -104,7 +104,13 @@ async function buildEntries(): Promise<SitemapEntry[]> {
       payload.find({
         collection: "services",
         where: { _status: { equals: "published" } },
-        locale: "all",
+        // Use the default locale here — `locale: "all"` returns localized
+        // fields as `{ en, nl }` envelope objects, which makes truthiness
+        // checks in `hasPricingData` (specifically `startingPrice`, the only
+        // localized gating field) report true even when both values are
+        // empty. That mismatch caused noindex pages to be listed in the
+        // sitemap (the page render uses a flat locale and 404s).
+        locale: defaultLocale,
         limit: 0,
         pagination: false,
       }),


### PR DESCRIPTION
## Summary

- Fixes the SEO crawler issue **noindex-page-in-sitemap** for `waterfox/pricing` (en + nl).
- The sitemap fetched services with `locale: "all"`, which returns localized fields as `{ en, nl }` envelope objects — always truthy. That caused `hasPricingData()` to gate on a truthy envelope for the localized `startingPrice` field, while the page's per-locale fetch correctly evaluated to false and called `notFound()`. Result: noindex URLs ended up in `sitemap.xml`.
- Switching the services fetch to `locale: defaultLocale` makes the gating evaluate against flat values, matching the page render. None of the other fields the sitemap reads from `services` are localized.

## Why only one issue from the crawl batch

The other 7 CSVs in this crawl run (canonical-points-to-redirect on scan.switch-to.eu, hreflang/html-lang on mailbox.org NL, hreflang-to-redirect on privnote/quiz/focus, duplicate title/description on google-drive-to-pcloud, /terms outbound link to ec.europa.eu/odr) were verified against the live site and are **already fixed** by earlier commits — the crawler data was stale.

Two broken outbound links remain in guide rich text (`proton.me/support/knowledge-base` in gmail-to-protonmail, `github.com/jcsalterego/sky-follower-bridge` in x-to-bluesky). Those are content/CMS, flagged separately to fix in admin.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — no new errors
- [x] Local dev server: `curl http://localhost:5010/sitemap.xml` — `waterfox/pricing` (en + nl) no longer present; `waterfox/security` and other services' `/pricing` + `/security` still present.
- [ ] After deploy: re-run the crawler and confirm noindex-page-in-sitemap reports zero waterfox URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)