### PR TITLE
chore(payload): switch to migration mode for production schema changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,33 @@ All internal packages use the `@switch-to-eu/` scope. Shared dependency versions
 
 **CSS imports chain:** Apps import global styles from `@switch-to-eu/ui/styles/globals.css`. The website's `postcss.config.mjs` re-exports from the UI package.
 
+## Database Migrations (Payload + Postgres)
+
+The website Payload instance runs in **migration mode in production, push mode in local dev**. Migrations live in `apps/website/migrations/` and are checked into git.
+
+**Local dev workflow** (push mode, no migrations needed for iteration):
+
+1. Edit a collection (`apps/website/collections/*.ts`)
+2. `pnpm dev` — Payload's postgres adapter syncs the schema diff to your dev DB on boot
+
+**Capturing the schema change as a migration** (before opening a PR):
+
+```bash
+pnpm --filter website migrate:create <descriptive-name>
+```
+
+This generates `apps/website/migrations/<timestamp>_<name>.ts`. Review the SQL `up`/`down` blocks, commit alongside the collection change.
+
+**Production deploy** runs `pnpm migrate` automatically as part of `vercel-build` (configured in `apps/website/vercel.json`). The `PAYLOAD_MIGRATING=true` env flag swaps `DATABASE_URL` for `DATABASE_URL_UNPOOLED` because pgbouncer rejects DDL transactions.
+
+**Other commands**:
+
+- `pnpm --filter website migrate` — apply pending migrations (used by `vercel-build`)
+- `pnpm --filter website migrate:status` — show which migrations are pending vs. applied
+- `pnpm --filter website migrate:fresh` — DROP and recreate everything (dev only, never prod)
+
+**Never** rename a column without an explicit migration plan. Push mode would interpret it as drop + add and lose the data.
+
 ## i18n
 
 Locales: `en` (default), `nl`. Managed by `@switch-to-eu/i18n` package using next-intl v4.

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev --port 5010",
     "build": "next build",
+    "vercel-build": "pnpm migrate && next build",
     "start": "next start",
     "prod": "cross-env VERCEL_ENV=production next build && cross-env VERCEL_ENV=production next start --port 5010",
     "lint": "eslint .",
@@ -16,6 +17,10 @@
     "test:e2e:ui": "playwright test --ui",
     "publish-all": "PAYLOAD_CONFIG_PATH=./payload.config.ts tsx --env-file=.env.local --env-file=../../.env scripts/publishAll.ts",
     "payload": "cross-env PAYLOAD_CONFIG_PATH=./payload.config.ts payload",
+    "migrate": "cross-env PAYLOAD_MIGRATING=true PAYLOAD_CONFIG_PATH=./payload.config.ts payload migrate",
+    "migrate:create": "cross-env PAYLOAD_MIGRATING=true PAYLOAD_CONFIG_PATH=./payload.config.ts payload migrate:create",
+    "migrate:status": "cross-env PAYLOAD_MIGRATING=true PAYLOAD_CONFIG_PATH=./payload.config.ts payload migrate:status",
+    "migrate:fresh": "cross-env PAYLOAD_MIGRATING=true PAYLOAD_CONFIG_PATH=./payload.config.ts payload migrate:fresh",
     "generate:types": "cross-env PAYLOAD_CONFIG_PATH=./payload.config.ts payload generate:types"
   },
   "dependencies": {

--- a/apps/website/payload.config.ts
+++ b/apps/website/payload.config.ts
@@ -38,7 +38,15 @@ export default buildConfig({
     },
   },
   db: postgresAdapter({
-    pool: { connectionString: process.env.DATABASE_URL! },
+    pool: {
+      // Migrations use the unpooled connection because pgbouncer/transaction
+      // poolers reject DDL statements; runtime falls back to the pooled URL.
+      connectionString:
+        process.env.PAYLOAD_MIGRATING === "true"
+          ? (process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL!)
+          : process.env.DATABASE_URL!,
+    },
+    migrationDir: path.resolve(__dirname, "migrations"),
   }),
   editor: lexicalEditor(),
   localization: {

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "fluid": true,
+  "buildCommand": "pnpm vercel-build",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

Switches the website's Payload postgres adapter from push mode to migration mode in production. Local dev keeps push mode for fast iteration. Schema changes are now reviewable as SQL diffs in PRs and applied atomically on deploy.

## What's in this PR

- `apps/website/payload.config.ts`: `migrationDir` set; `PAYLOAD_MIGRATING=true` env flag swaps `DATABASE_URL` for `DATABASE_URL_UNPOOLED` during DDL (pgbouncer rejects schema transactions on the pooled connection).
- `apps/website/package.json`: new scripts — `migrate`, `migrate:create`, `migrate:status`, `migrate:fresh`, `vercel-build`.
- `apps/website/vercel.json`: `buildCommand` set to `pnpm vercel-build`, which runs `pnpm migrate && next build` before each prod deploy. A failed migration fails the deploy and prod stays on the previous build.
- `apps/website/migrations/.gitkeep`: directory placeholder.
- `CLAUDE.md`: new Database Migrations section.

## What's NOT in this PR (must happen before merge)

### 1. Generate the baseline migration locally

This was deliberately not committed by the assistant — the SQL needs human review. Run on a dev DB whose schema matches prod (after PR #244 has fully deployed):

```bash
cd apps/website
pnpm migrate:create initial-baseline
```

Review the generated `apps/website/migrations/<timestamp>_initial-baseline.ts`. Confirm it represents the current shared schema (services with `oneLineProblem`, `whatYoudGain`, `whatYoudLose`, `faqs`, `angle`; categories; guides; etc.). Commit it to this branch.

### 2. Mark the baseline as already applied on prod

One-time manual step on the prod DB. Without it, the first deploy with `pnpm migrate` enabled will try to recreate tables that already exist and error.

```sql
INSERT INTO payload_migrations (name, batch)
VALUES ('<filename-without-.ts-extension>', 1);
```

Run via Vercel Postgres → Query (or whatever the prod DB console is). Use `DATABASE_URL_UNPOOLED` if connecting from a tool.

### 3. Then merge this PR

After the baseline file is committed AND prod has the row marking it applied, merging triggers a deploy. `pnpm migrate` runs on Vercel build, sees the baseline is already applied (no-op), the build succeeds, traffic cuts over.

## Test plan

- [ ] `pnpm migrate:status` locally shows the baseline as pending (until applied locally) or applied if you ran it.
- [ ] `pnpm vercel-build` locally with `DATABASE_URL_UNPOOLED` set succeeds end-to-end.
- [ ] Deploy preview on Vercel shows `pnpm migrate` running in build logs and completing before `next build`.
- [ ] After merge, prod deploy logs show `migrate` finding the baseline already applied (one row in `payload_migrations`) and zero new migrations.

## Future workflow

For any schema change after this lands:

1. Edit a collection in `apps/website/collections/`.
2. `pnpm dev` — push mode applies it locally for testing.
3. `pnpm migrate:create <descriptive-name>` — generates the migration file.
4. Commit collection change + migration file together in the PR.
5. Reviewers see the SQL diff alongside the schema change.
6. Deploy runs the migration before the new code goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)